### PR TITLE
feat: implement Phase 0 UI + Phase 1 planning loop

### DIFF
--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -1,0 +1,94 @@
+# Dev Notes
+
+Quick reference for local development.
+
+## Starting the app
+
+```bash
+bash dev-start.sh   # first time (or after a clean wipe)
+pnpm dev            # start the Next.js dev server
+```
+
+## URLs
+
+| URL | What |
+|---|---|
+| http://localhost:3000 | App |
+| http://localhost:8025 | Mailhog — catches all dev emails |
+| http://localhost:9001 | MinIO console — file storage (login: `minioadmin` / `minioadmin`) |
+
+## Test accounts
+
+All have password: **`password123`**
+
+| Email | Username | Notes |
+|---|---|---|
+| alice@campfire.local | @alice | Owner of "Friday Night Squad", friends with bob + carol |
+| bob@campfire.local | @bob | Member of "Friday Night Squad", friends with alice |
+| carol@campfire.local | @carol | Member of "Friday Night Squad", friends with alice |
+
+Seed is safe to re-run — it skips rows that already exist:
+```bash
+pnpm db:seed
+```
+
+## Useful commands
+
+| Command | What |
+|---|---|
+| `pnpm dev` | Next.js dev server |
+| `pnpm db:studio` | Drizzle Studio — browse/edit the database in a UI |
+| `pnpm db:seed` | Create test accounts + group |
+| `pnpm db:generate` | Generate a new migration from schema changes |
+| `pnpm db:migrate` | Apply pending migrations |
+| `pnpm typecheck` | TypeScript check |
+| `pnpm lint` | ESLint |
+| `pnpm test:run` | Vitest unit tests |
+
+## Docker
+
+```bash
+docker-compose up -d      # start all services
+docker-compose down       # stop all services
+docker-compose logs -f    # tail logs from all services
+```
+
+## Session notes
+
+- Sessions expire after 7 days (better-auth default). If you're redirected to `/login` mid-session, just log in again.
+- In dev, a Next.js hot-reload can briefly reset the DB connection pool. The layout catches this and redirects cleanly rather than crashing.
+
+## Features built (Phase 1)
+
+| Feature | Route |
+|---|---|
+| Games library | `/games` — add games, filter by platform, remove |
+| Availability | `/availability` — week view, add/edit/delete time blocks with visibility controls |
+| Events | `/events` — create events per group, list with status badges |
+| Event detail + polls | `/events/[id]` — RSVP, poll voting with live bars, confirm/cancel (creator) |
+| Email jobs | BullMQ: event confirmed/cancelled, RSVP reminder (24h before), poll opened/closed |
+| Settings + notification prefs | `/settings` — username, toggle every email/in-app category |
+
+## Adding yourself to seed data
+
+The seed accounts are fixed. To connect your own account to them, run SQL directly:
+
+```bash
+docker-compose exec postgres psql -U campfire -d campfire
+```
+
+```sql
+-- Accept a pending friend request from your account to alice
+UPDATE friendships SET status = 'accepted', updated_at = NOW()
+  WHERE requester_id = '<your-id>' AND addressee_id = 'seed-user-alice';
+
+-- Add yourself to the Friday Night Squad group
+INSERT INTO group_memberships (group_id, user_id, role, joined_at)
+  VALUES ('seed-group-main', '<your-id>', 'member', NOW())
+  ON CONFLICT DO NOTHING;
+```
+
+Find your user ID:
+```sql
+SELECT id, email FROM "user";
+```

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ ProjectCampfire is a self-hostable platform that helps friend groups decide what
 | API | tRPC v11 |
 | Database | PostgreSQL 16 |
 | ORM | Drizzle ORM |
-| Auth | Lucia Auth |
+| Auth | better-auth |
 | Jobs | BullMQ + Redis |
 | Storage | MinIO (S3-compatible) |
 | Email | Nodemailer + SMTP relay |
@@ -48,27 +48,19 @@ ProjectCampfire is a self-hostable platform that helps friend groups decide what
 git clone https://github.com/your-org/projectcampfire.git
 cd projectcampfire
 
-# Copy environment variables
-cp .env.example .env
-
-# Start all services
-docker compose up -d
-
-# Install dependencies
-pnpm install
-
-# Run database migrations
-pnpm db:migrate
-
-# Seed development data (optional)
-pnpm db:seed
+# First-time setup (checks prereqs, creates .env, starts Docker, runs migrations)
+bash dev-start.sh
 
 # Start the development server
 pnpm dev
 ```
 
-The app will be available at `http://localhost:3000`.
-Mailhog (dev email catcher) runs at `http://localhost:8025`.
+| URL | Purpose |
+|---|---|
+| http://localhost:3000 | App |
+| http://localhost:8025 | Mailhog — catches all dev emails |
+| http://localhost:9001 | MinIO console (login: `minioadmin` / `minioadmin`) |
+
 Drizzle Studio (database GUI) runs via `pnpm db:studio`.
 
 ### Production (self-hosted)

--- a/dev-start.sh
+++ b/dev-start.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# ProjectCampfire — dev startup script
+# Run this from the project root: bash dev-start.sh
+
+set -e
+
+BOLD="\033[1m"
+GREEN="\033[32m"
+YELLOW="\033[33m"
+RED="\033[31m"
+RESET="\033[0m"
+
+step() { echo -e "\n${BOLD}$1${RESET}"; }
+ok()   { echo -e "${GREEN}✓ $1${RESET}"; }
+warn() { echo -e "${YELLOW}⚠ $1${RESET}"; }
+fail() { echo -e "${RED}✗ $1${RESET}"; exit 1; }
+
+# ── 1. Check prerequisites ────────────────────────────────────────────────────
+step "Checking prerequisites..."
+
+command -v node  >/dev/null 2>&1 || fail "Node.js not found. Install from https://nodejs.org"
+command -v pnpm  >/dev/null 2>&1 || fail "pnpm not found. Run: npm install -g pnpm"
+command -v docker >/dev/null 2>&1 || fail "Docker not found. Install Docker Desktop."
+docker info >/dev/null 2>&1      || fail "Docker is not running. Please start Docker Desktop first."
+
+ok "Node $(node -v), pnpm $(pnpm -v), Docker ready"
+
+# ── 2. Check .env ─────────────────────────────────────────────────────────────
+step "Checking .env file..."
+
+if [ ! -f ".env" ]; then
+  warn ".env not found — copying from .env.example"
+  cp .env.example .env
+fi
+
+if grep -q 'AUTH_SECRET=""' .env; then
+  warn "AUTH_SECRET is empty — generating one now"
+  SECRET=$(openssl rand -base64 32)
+  sed -i "s|AUTH_SECRET=\"\"|AUTH_SECRET=\"$SECRET\"|" .env
+  ok "AUTH_SECRET generated"
+else
+  ok ".env looks good"
+fi
+
+# ── 3. Install dependencies ───────────────────────────────────────────────────
+step "Installing dependencies..."
+pnpm install --frozen-lockfile
+ok "Dependencies installed"
+
+# ── 4. Start Docker services ──────────────────────────────────────────────────
+step "Starting Docker services (Postgres, Redis, MinIO, Mailhog)..."
+docker-compose up -d
+
+# Wait for Postgres to be healthy
+echo "Waiting for Postgres to be ready..."
+for i in $(seq 1 20); do
+  if docker-compose exec -T postgres pg_isready -U campfire >/dev/null 2>&1; then
+    ok "Postgres ready"
+    break
+  fi
+  if [ "$i" -eq 20 ]; then
+    fail "Postgres did not become ready in time. Check: docker-compose logs postgres"
+  fi
+  sleep 1
+done
+
+# ── 5. Run migrations ─────────────────────────────────────────────────────────
+step "Running database migrations..."
+pnpm db:generate
+pnpm db:migrate
+ok "Migrations applied"
+
+# ── 6. Seed database ──────────────────────────────────────────────────────────
+step "Seeding database with test accounts..."
+pnpm db:seed
+ok "Seed complete"
+
+# ── 7. Done ───────────────────────────────────────────────────────────────────
+echo ""
+echo -e "${BOLD}${GREEN}Everything is ready!${RESET}"
+echo ""
+echo "  App:        http://localhost:3000"
+echo "  Mailhog:    http://localhost:8025  (catches all dev emails)"
+echo "  MinIO:      http://localhost:9001  (login: minioadmin / minioadmin)"
+echo ""
+echo "  Test accounts (password: password123):"
+echo "    alice@campfire.local  @alice"
+echo "    bob@campfire.local    @bob"
+echo "    carol@campfire.local  @carol"
+echo ""
+echo -e "Now run: ${BOLD}pnpm dev${RESET}"
+echo ""

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -8,7 +8,7 @@
 | API layer | tRPC v11 | Type-safe end-to-end with no schema maintenance; REST adapter available if needed later |
 | Database | PostgreSQL 16 | Relational model fits the domain exactly; JSONB for flexible metadata; full-text search built-in; trivially self-hostable |
 | ORM | Drizzle ORM | Type-safe; SQL-close; migrations output inspectable SQL files |
-| Auth | Lucia Auth | Self-hostable; no third-party auth service dependency; email/password now, OAuth later |
+| Auth | better-auth | Self-hostable; no third-party auth service dependency; email/password now, OAuth later |
 | Background jobs | BullMQ + Redis | Email delivery, OG tag fetching, image processing, poll auto-close, Steam sync (Phase 2) |
 | Sessions / cache | Redis (Valkey) | Fast session store; BullMQ queue backend |
 | Object storage | MinIO | S3-compatible; self-hostable; swap to real S3 with one env var change |
@@ -53,7 +53,7 @@
                         │  └─────────┘         │  ├────────────────────────┤  │ │
                         │                      │  │  tRPC API Routes       │  │ │
                         │                      │  ├────────────────────────┤  │ │
-                        │                      │  │  Auth (Lucia)          │  │ │
+                        │                      │  │  Auth (better-auth)    │  │ │
                         │                      │  ├────────────────────────┤  │ │
                         │                      │  │  OG Unfurl (queued)    │  │ │
                         │                      │  ├────────────────────────┤  │ │
@@ -186,7 +186,7 @@ WHERE p.deleted_at IS NULL
     p.repost_of_id IS NULL
     OR EXISTS (
       SELECT 1 FROM posts op
-      JOIN users u ON u.id = op.author_id
+      JOIN "user" u ON u.id = op.author_id
       WHERE op.id = p.repost_of_id
         AND op.deleted_at IS NULL
         AND u.profile_visibility = 'open'

--- a/docs/TECH_DEBT.md
+++ b/docs/TECH_DEBT.md
@@ -1,0 +1,53 @@
+# Tech Debt & Known Issues
+
+Items to address in Phase 1 polish or Phase 2. Not blockers for feature development.
+
+---
+
+## Feed / Posts
+
+| # | Issue | Notes |
+|---|---|---|
+| ~~TD-001~~ | ~~Comment ordering~~ | Fixed — oldest-first, limit 20 |
+| ~~TD-002~~ | ~~Comment timestamp hover~~ | Fixed — `title` attribute on timestamp |
+| TD-003 | Comment author name shown inside the bubble | Consider name above bubble for clarity |
+| TD-004 | Like on comments not implemented | `toggleLike` only handles posts. Extend to accept `commentId` too (CAMP-089) |
+| TD-005 | Repost not implemented | CAMP-090–093. Needs permission check (`profile_visibility = open`) |
+| TD-006 | Post edit not implemented | CAMP-086. Update body, set `editedAt`, show "edited" label |
+| TD-007 | Feed only loads 20 posts, no pagination | Cursor-based pagination wired in router but no "load more" button |
+| TD-008 | No optimistic updates on like/comment | Full feed refetch on action. Fine for now, noticeable on slow connections |
+
+## Auth / Profile
+
+| # | Issue | Notes |
+|---|---|---|
+| TD-009 | No avatar upload yet | CAMP-005. MinIO + Sharp pipeline needed |
+| TD-010 | Password reset landing page not built | `/reset-password` page for the email link — CAMP-003 |
+| TD-011 | Username change cooldown not enforced | 30-day cooldown stored (`usernameChangedAt`) but not checked in `setUsername` |
+| TD-012 | No profile page (`/u/[username]`) | CAMP-021. Open profiles + add-friend button; private profiles minimal |
+| TD-018 | Display name edit in Settings is cosmetic only | Field exists but mutation not wired — needs a `setDisplayName` procedure |
+
+## Groups
+
+| # | Issue | Notes |
+|---|---|---|
+| TD-013 | No active nav link highlighting | All nav links same colour regardless of current route |
+| TD-014 | Group invite link uses placeholder on onboarding step 3 | Needs real per-user invite token (CAMP-022) |
+
+## Events / Polls
+
+| # | Issue | Notes |
+|---|---|---|
+| TD-019 | No group overlap view on availability page | `groupOverlap` router procedure exists but no UI yet |
+| TD-020 | Poll auto-close via BullMQ not implemented | `closesAt` field exists but no scheduled job to close polls when time elapses |
+| TD-021 | Event RSVP reminder job only scheduled on confirm | Members who RSVP after confirm don't update the reminder list |
+| TD-022 | My RSVP status not highlighted on event detail | RSVP buttons don't show current selection (need to compare against `event.rsvps`) |
+
+## Infrastructure
+
+| # | Issue | Notes |
+|---|---|---|
+| TD-015 | Rate limiting not implemented | CAMP-156. Search, registration, post submission all need rate limiting |
+| TD-016 | Image upload validation not implemented | CAMP-157. Type allowlist + 5MB size limit needed before MinIO uploads |
+| TD-017 | No `/api/health` endpoint | CAMP-159. Simple liveness check for production monitoring |
+| TD-023 | Better-auth session occasionally drops in dev | Hot-reload resets DB pool; layout now catches the error gracefully. Not a prod issue |

--- a/package.json
+++ b/package.json
@@ -22,6 +22,11 @@
     "db:seed": "tsx src/server/db/seed.ts"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.2.2",
+    "@paralleldrive/cuid2": "^3.3.0",
+    "@radix-ui/react-avatar": "^1.1.11",
+    "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-slot": "^1.2.4",
     "@t3-oss/env-nextjs": "^0.13.10",
     "@tanstack/react-query": "^5.66.0",
@@ -32,6 +37,7 @@
     "bullmq": "^5.31.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
+    "date-fns": "^4.1.0",
     "drizzle-orm": "^0.41.0",
     "ioredis": "^5.3.2",
     "lucide-react": "^0.475.0",
@@ -41,6 +47,7 @@
     "postgres": "^3.4.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-hook-form": "^7.71.2",
     "server-only": "^0.0.1",
     "sharp": "^0.33.0",
     "superjson": "^2.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,21 @@ importers:
 
   .:
     dependencies:
+      '@hookform/resolvers':
+        specifier: ^5.2.2
+        version: 5.2.2(react-hook-form@7.71.2(react@19.2.4))
+      '@paralleldrive/cuid2':
+        specifier: ^3.3.0
+        version: 3.3.0
+      '@radix-ui/react-avatar':
+        specifier: ^1.1.11
+        version: 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-dialog':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-label':
+        specifier: ^2.1.8
+        version: 2.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.2.14)(react@19.2.4)
@@ -41,6 +56,9 @@ importers:
       clsx:
         specifier: ^2.1.0
         version: 2.1.1
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.1.0
       drizzle-orm:
         specifier: ^0.41.0
         version: 0.41.0(@electric-sql/pglite@0.3.15)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(gel@2.2.0)(kysely@0.28.11)(mysql2@3.15.3)(postgres@3.4.8)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))
@@ -68,6 +86,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
+      react-hook-form:
+        specifier: ^7.71.2
+        version: 7.71.2(react@19.2.4)
       server-only:
         specifier: ^0.0.1
         version: 0.0.1
@@ -991,6 +1012,11 @@ packages:
     peerDependencies:
       hono: ^4
 
+  '@hookform/resolvers@5.2.2':
+    resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
+    peerDependencies:
+      react-hook-form: ^7.55.0
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -1418,6 +1444,10 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
+  '@paralleldrive/cuid2@3.3.0':
+    resolution: {integrity: sha512-OqiFvSOF0dBSesELYY2CAMa4YINvlLpvKOz/rv6NeZEqiyttlHgv98Juwv4Ch+GrEV7IZ8jfI2VcEoYUjXXCjw==}
+    hasBin: true
+
   '@petamoriken/float16@3.9.3':
     resolution: {integrity: sha512-8awtpHXCx/bNpFt4mt2xdkgtgVvKqty8VbjHI/WWWQuEw+KLzFot3f4+LkQY9YmOtq7A5GdOnqoIC8Pdygjk2g==}
 
@@ -1473,6 +1503,22 @@ packages:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
+  '@radix-ui/primitive@1.1.3':
+    resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
+  '@radix-ui/react-avatar@1.1.11':
+    resolution: {integrity: sha512-0Qk603AHGV28BOBO34p7IgD5m+V5Sg/YovfayABkoDDBM5d3NCx0Mp4gGrjzLGes1jV5eNOE1r3itqOR33VC6Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-compose-refs@1.1.2':
     resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
     peerDependencies:
@@ -1482,8 +1528,211 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-context@1.1.2':
+    resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.3':
+    resolution: {integrity: sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dialog@1.1.15':
+    resolution: {integrity: sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.11':
+    resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-focus-guards@1.1.3':
+    resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.7':
+    resolution: {integrity: sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-id@1.1.1':
+    resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-label@2.1.8':
+    resolution: {integrity: sha512-FmXs37I6hSBVDlO4y764TNz1rLgKwjJMQ0EGte6F3Cb3f4bIuHB/iLa/8I9VKkmOy+gNHq8rql3j686ACVV21A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.9':
+    resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.5':
+    resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.3':
+    resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.4':
+    resolution: {integrity: sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.3':
+    resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-slot@1.2.4':
     resolution: {integrity: sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.1':
+    resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.2':
+    resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.2':
+    resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-escape-keydown@1.1.1':
+    resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-is-hydrated@0.1.0':
+    resolution: {integrity: sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.1':
+    resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1640,6 +1889,9 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -1981,6 +2233,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
+
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
@@ -2138,6 +2394,9 @@ packages:
     peerDependenciesMeta:
       zod:
         optional: true
+
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
@@ -2335,6 +2594,9 @@ packages:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
 
+  date-fns@4.1.0:
+    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
+
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
     peerDependencies:
@@ -2395,6 +2657,9 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  detect-node-es@1.1.0:
+    resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
@@ -2527,6 +2792,9 @@ packages:
   env-paths@3.0.0:
     resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  error-causes@3.0.2:
+    resolution: {integrity: sha512-i0B8zq1dHL6mM85FGoxaJnVtx6LD5nL2v0hlpGdntg5FOSyzQ46c9lmz5qx0xRS2+PWHGOHcYxGIBC5Le2dRMw==}
 
   es-abstract@1.24.1:
     resolution: {integrity: sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==}
@@ -2841,6 +3109,10 @@ packages:
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
+
+  get-nonce@1.0.1:
+    resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
+    engines: {node: '>=6'}
 
   get-port-please@3.2.0:
     resolution: {integrity: sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A==}
@@ -3618,12 +3890,48 @@ packages:
     peerDependencies:
       react: ^19.2.4
 
+  react-hook-form@7.71.2:
+    resolution: {integrity: sha512-1CHvcDYzuRUNOflt4MOq3ZM46AronNJtQ1S7tnX6YN4y72qhgiUItpacZUAQ0TyWYci3yz1X+rXaSxiuEm86PA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
+
+  react-remove-scroll-bar@2.3.8:
+    resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-remove-scroll@2.7.2:
+    resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-style-singleton@2.2.3:
+    resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
@@ -4065,6 +4373,31 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  use-callback-ref@1.3.3:
+    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-sidecar@1.1.3:
+    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -4827,6 +5160,11 @@ snapshots:
     dependencies:
       hono: 4.11.4
 
+  '@hookform/resolvers@5.2.2(react-hook-form@7.71.2(react@19.2.4))':
+    dependencies:
+      '@standard-schema/utils': 0.3.0
+      react-hook-form: 7.71.2(react@19.2.4)
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -5113,6 +5451,12 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
+  '@paralleldrive/cuid2@3.3.0':
+    dependencies:
+      '@noble/hashes': 2.0.1
+      bignumber.js: 9.3.1
+      error-causes: 3.0.2
+
   '@petamoriken/float16@3.9.3':
     optional: true
 
@@ -5191,8 +5535,148 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
+  '@radix-ui/primitive@1.1.3': {}
+
+  '@radix-ui/react-avatar@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-context@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-context@1.1.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      aria-hidden: 1.2.6
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-id@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-label@2.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-primitive@2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-slot@1.2.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
     optionalDependencies:
       '@types/react': 19.2.14
@@ -5200,6 +5684,47 @@ snapshots:
   '@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-is-hydrated@0.1.0(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      use-sync-external-store: 1.6.0(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
       react: 19.2.4
     optionalDependencies:
       '@types/react': 19.2.14
@@ -5286,6 +5811,8 @@ snapshots:
   '@rushstack/eslint-patch@1.16.1': {}
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -5615,6 +6142,10 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
+
   aria-query@5.3.2: {}
 
   array-buffer-byte-length@1.0.2:
@@ -5760,6 +6291,8 @@ snapshots:
       set-cookie-parser: 3.0.1
     optionalDependencies:
       zod: 4.3.6
+
+  bignumber.js@9.3.1: {}
 
   binary-extensions@2.3.0: {}
 
@@ -5982,6 +6515,8 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
+  date-fns@4.1.0: {}
+
   debug@3.2.7:
     dependencies:
       ms: 2.1.3
@@ -6021,6 +6556,8 @@ snapshots:
   destr@2.0.5: {}
 
   detect-libc@2.1.2: {}
+
+  detect-node-es@1.1.0: {}
 
   didyoumean@1.2.2: {}
 
@@ -6072,6 +6609,8 @@ snapshots:
 
   env-paths@3.0.0:
     optional: true
+
+  error-causes@3.0.2: {}
 
   es-abstract@1.24.1:
     dependencies:
@@ -6634,6 +7173,8 @@ snapshots:
       has-symbols: 1.1.0
       hasown: 2.0.2
       math-intrinsics: 1.1.0
+
+  get-nonce@1.0.1: {}
 
   get-port-please@3.2.0: {}
 
@@ -7400,9 +7941,40 @@ snapshots:
       react: 19.2.4
       scheduler: 0.27.0
 
+  react-hook-form@7.71.2(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+
   react-is@16.13.1: {}
 
   react-refresh@0.17.0: {}
+
+  react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.4)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  react-remove-scroll@2.7.2(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-remove-scroll-bar: 2.3.8(@types/react@19.2.14)(react@19.2.4)
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.4)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@19.2.14)(react@19.2.4)
+      use-sidecar: 1.1.3(@types/react@19.2.14)(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  react-style-singleton@2.2.3(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      get-nonce: 1.0.1
+      react: 19.2.4
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   react@19.2.4: {}
 
@@ -7995,6 +8567,25 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  use-sidecar@1.1.3(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 19.2.4
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  use-sync-external-store@1.6.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
 
   util-deprecate@1.0.2: {}
 

--- a/src/app/(app)/availability/page.tsx
+++ b/src/app/(app)/availability/page.tsx
@@ -1,0 +1,316 @@
+"use client";
+
+import { useState } from "react";
+import { api } from "@/trpc/react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  addDays,
+  startOfWeek,
+  format,
+  parseISO,
+  isSameDay,
+  formatISO,
+} from "date-fns";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function toLocalDatetimeValue(d: Date) {
+  // Returns a string suitable for <input type="datetime-local">
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function fromLocalDatetimeValue(s: string): string {
+  // Convert local datetime-local value to ISO string (with timezone offset)
+  return new Date(s).toISOString();
+}
+
+function formatTimeRange(start: Date | string, end: Date | string) {
+  const s = typeof start === "string" ? parseISO(start) : start;
+  const e = typeof end === "string" ? parseISO(end) : end;
+  return `${format(s, "HH:mm")} – ${format(e, "HH:mm")}`;
+}
+
+const VISIBILITIES = ["friends", "group", "private"] as const;
+type Visibility = (typeof VISIBILITIES)[number];
+
+const VIS_LABELS: Record<Visibility, string> = {
+  friends: "Friends",
+  group: "Group only",
+  private: "Private",
+};
+
+// ── Add / Edit block dialog ───────────────────────────────────────────────────
+
+type Block = {
+  id: string;
+  startsAt: Date | string;
+  endsAt: Date | string;
+  label: string | null;
+  visibility: string;
+  groupId: string | null;
+};
+
+function BlockDialog({
+  trigger,
+  initial,
+  onDone,
+}: {
+  trigger: React.ReactNode;
+  initial?: Block;
+  onDone: () => void;
+}) {
+  const now = new Date();
+  const [open, setOpen] = useState(false);
+  const [startsAt, setStartsAt] = useState(
+    initial ? toLocalDatetimeValue(new Date(initial.startsAt)) : toLocalDatetimeValue(now)
+  );
+  const [endsAt, setEndsAt] = useState(
+    initial
+      ? toLocalDatetimeValue(new Date(initial.endsAt))
+      : toLocalDatetimeValue(addDays(now, 0))
+  );
+  const [label, setLabel] = useState(initial?.label ?? "");
+  const [visibility, setVisibility] = useState<Visibility>(
+    (initial?.visibility as Visibility) ?? "friends"
+  );
+  const [error, setError] = useState("");
+
+  const create = api.availability.create.useMutation({
+    onSuccess: () => { setOpen(false); onDone(); },
+    onError: (e) => setError(e.message),
+  });
+  const update = api.availability.update.useMutation({
+    onSuccess: () => { setOpen(false); onDone(); },
+    onError: (e) => setError(e.message),
+  });
+
+  const isPending = create.isPending || update.isPending;
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+    const payload = {
+      startsAt: fromLocalDatetimeValue(startsAt),
+      endsAt: fromLocalDatetimeValue(endsAt),
+      label: label.trim() || undefined,
+      visibility,
+    };
+    if (initial) {
+      update.mutate({ id: initial.id, ...payload });
+    } else {
+      create.mutate(payload);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>{trigger}</DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{initial ? "Edit availability" : "Add availability block"}</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {error && (
+            <p className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+              {error}
+            </p>
+          )}
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-2">
+              <Label htmlFor="avail-start">Start</Label>
+              <Input
+                id="avail-start"
+                type="datetime-local"
+                required
+                value={startsAt}
+                onChange={(e) => setStartsAt(e.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="avail-end">End</Label>
+              <Input
+                id="avail-end"
+                type="datetime-local"
+                required
+                value={endsAt}
+                onChange={(e) => setEndsAt(e.target.value)}
+              />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="avail-label">Label (optional)</Label>
+            <Input
+              id="avail-label"
+              placeholder="e.g. Friday evening"
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label>Visibility</Label>
+            <div className="flex flex-wrap gap-2">
+              {VISIBILITIES.map((v) => (
+                <button
+                  key={v}
+                  type="button"
+                  onClick={() => setVisibility(v)}
+                  className={`rounded-md border px-3 py-1 text-sm transition-colors ${
+                    visibility === v
+                      ? "border-primary bg-primary text-primary-foreground"
+                      : "hover:bg-muted"
+                  }`}
+                >
+                  {VIS_LABELS[v]}
+                </button>
+              ))}
+            </div>
+          </div>
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="outline" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isPending}>
+              {isPending ? "Saving…" : initial ? "Save changes" : "Add block"}
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ── Week navigator ────────────────────────────────────────────────────────────
+
+function WeekNav({
+  weekStart,
+  onChange,
+}: {
+  weekStart: Date;
+  onChange: (d: Date) => void;
+}) {
+  return (
+    <div className="flex items-center gap-3">
+      <Button variant="outline" size="sm" onClick={() => onChange(addDays(weekStart, -7))}>
+        ‹
+      </Button>
+      <span className="text-sm font-medium">
+        {format(weekStart, "d MMM")} – {format(addDays(weekStart, 6), "d MMM yyyy")}
+      </span>
+      <Button variant="outline" size="sm" onClick={() => onChange(addDays(weekStart, 7))}>
+        ›
+      </Button>
+    </div>
+  );
+}
+
+// ── Main page ─────────────────────────────────────────────────────────────────
+
+export default function AvailabilityPage() {
+  const [weekStart, setWeekStart] = useState(() =>
+    startOfWeek(new Date(), { weekStartsOn: 1 })
+  );
+  const weekEnd = addDays(weekStart, 7);
+
+  const { data: myBlocks = [], refetch } = api.availability.myBlocks.useQuery({
+    from: formatISO(weekStart),
+    to: formatISO(weekEnd),
+  });
+
+  const deleteBlock = api.availability.delete.useMutation({
+    onSuccess: () => void refetch(),
+  });
+
+  const days = Array.from({ length: 7 }, (_, i) => addDays(weekStart, i));
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">My Availability</h1>
+          <p className="text-muted-foreground text-sm">
+            Let friends and groups know when you&apos;re free to play.
+          </p>
+        </div>
+        <BlockDialog
+          trigger={<Button>Add block</Button>}
+          onDone={() => void refetch()}
+        />
+      </div>
+
+      <WeekNav weekStart={weekStart} onChange={setWeekStart} />
+
+      <div className="space-y-3">
+        {days.map((day) => {
+          const dayBlocks = myBlocks.filter((b) =>
+            isSameDay(new Date(b.startsAt), day)
+          );
+          return (
+            <div key={day.toISOString()} className="rounded-lg border">
+              <div className="flex items-center justify-between border-b px-3 py-2">
+                <span className="text-sm font-medium">{format(day, "EEEE d MMM")}</span>
+                <BlockDialog
+                  trigger={
+                    <button className="text-xs text-muted-foreground hover:text-foreground">
+                      + Add
+                    </button>
+                  }
+                  onDone={() => void refetch()}
+                />
+              </div>
+              {dayBlocks.length === 0 ? (
+                <p className="px-3 py-3 text-xs text-muted-foreground">No blocks</p>
+              ) : (
+                <ul className="divide-y">
+                  {dayBlocks.map((b) => (
+                    <li key={b.id} className="flex items-center justify-between px-3 py-2">
+                      <div className="flex items-center gap-2">
+                        <span className="text-sm">
+                          {formatTimeRange(b.startsAt, b.endsAt)}
+                        </span>
+                        {b.label && (
+                          <span className="text-sm text-muted-foreground">{b.label}</span>
+                        )}
+                        <Badge variant="secondary" className="text-xs">
+                          {VIS_LABELS[b.visibility as Visibility]}
+                        </Badge>
+                      </div>
+                      <div className="flex items-center gap-1">
+                        <BlockDialog
+                          trigger={
+                            <button className="text-xs text-muted-foreground hover:text-foreground px-2 py-1">
+                              Edit
+                            </button>
+                          }
+                          initial={b}
+                          onDone={() => void refetch()}
+                        />
+                        <button
+                          onClick={() => deleteBlock.mutate({ id: b.id })}
+                          disabled={deleteBlock.isPending}
+                          className="text-xs text-muted-foreground hover:text-destructive px-2 py-1"
+                        >
+                          Remove
+                        </button>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/events/[id]/page.tsx
+++ b/src/app/(app)/events/[id]/page.tsx
@@ -1,0 +1,392 @@
+"use client";
+
+import { use } from "react";
+import { useRouter } from "next/navigation";
+import { api } from "@/trpc/react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { format } from "date-fns";
+import { useState } from "react";
+
+// ── Types from router inference ───────────────────────────────────────────────
+
+const STATUS_LABEL: Record<string, string> = {
+  draft: "Draft",
+  open: "Open",
+  confirmed: "Confirmed",
+  cancelled: "Cancelled",
+};
+
+const RSVP_LABELS = { yes: "Going", no: "Not going", maybe: "Maybe" } as const;
+type RsvpStatus = keyof typeof RSVP_LABELS;
+
+// ── Poll card ─────────────────────────────────────────────────────────────────
+
+function PollCard({
+  poll,
+  myUserId,
+  onVote,
+}: {
+  poll: {
+    id: string;
+    question: string;
+    status: string;
+    allowMultipleVotes: string;
+    createdBy: string;
+    options: {
+      id: string;
+      label: string;
+      votes: { userId: string }[];
+      startsAt?: Date | string | null;
+      endsAt?: Date | string | null;
+    }[];
+  };
+  myUserId: string;
+  onVote: () => void;
+}) {
+  const vote = api.polls.vote.useMutation({ onSuccess: onVote });
+  const closePoll = api.polls.close.useMutation({ onSuccess: onVote });
+
+  const totalVotes = poll.options.reduce((s, o) => s + o.votes.length, 0);
+  const isClosed = poll.status === "closed";
+  const isCreator = poll.createdBy === myUserId;
+
+  return (
+    <div className="rounded-lg border p-4 space-y-3">
+      <div className="flex items-start justify-between gap-2">
+        <div>
+          <p className="font-medium">{poll.question}</p>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            {totalVotes} vote{totalVotes === 1 ? "" : "s"} ·{" "}
+            {poll.allowMultipleVotes === "true" ? "Multiple choice" : "Single choice"}
+          </p>
+        </div>
+        {isClosed ? (
+          <Badge variant="secondary" className="text-xs shrink-0">Closed</Badge>
+        ) : (
+          <Badge variant="default" className="text-xs shrink-0">Open</Badge>
+        )}
+      </div>
+
+      <ul className="space-y-1.5">
+        {poll.options.map((opt) => {
+          const count = opt.votes.length;
+          const pct = totalVotes > 0 ? Math.round((count / totalVotes) * 100) : 0;
+          return (
+            <li key={opt.id}>
+              <button
+                disabled={isClosed || vote.isPending}
+                onClick={() => vote.mutate({ pollOptionId: opt.id })}
+                className="w-full text-left"
+              >
+                <div className={`flex items-center justify-between text-sm mb-0.5 ${opt.votes.some((v) => v.userId === myUserId) ? "font-medium" : ""}`}>
+                  <span>
+                    {opt.label}
+                    {opt.startsAt && (
+                      <span className="text-muted-foreground ml-1.5">
+                        {format(new Date(opt.startsAt), "d MMM HH:mm")}
+                        {opt.endsAt && ` – ${format(new Date(opt.endsAt), "HH:mm")}`}
+                      </span>
+                    )}
+                  </span>
+                  <span className="text-muted-foreground text-xs ml-2 shrink-0">
+                    {count} ({pct}%)
+                  </span>
+                </div>
+                <div className="h-1.5 rounded-full bg-muted overflow-hidden">
+                  <div
+                    className="h-full bg-primary transition-all"
+                    style={{ width: `${pct}%` }}
+                  />
+                </div>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+
+      {!isClosed && isCreator && (
+        <button
+          onClick={() => closePoll.mutate({ id: poll.id })}
+          disabled={closePoll.isPending}
+          className="text-xs text-muted-foreground hover:text-foreground"
+        >
+          Close poll
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ── Create poll dialog ────────────────────────────────────────────────────────
+
+function CreatePollDialog({ eventId, groupId, onCreated }: { eventId: string; groupId: string; onCreated: () => void }) {
+  const [open, setOpen] = useState(false);
+  const [question, setQuestion] = useState("");
+  const [type, setType] = useState<"time_slot" | "game" | "custom">("custom");
+  const [options, setOptions] = useState(["", ""]);
+  const [error, setError] = useState("");
+
+  const create = api.polls.create.useMutation({
+    onSuccess: () => { setOpen(false); setQuestion(""); setOptions(["", ""]); onCreated(); },
+    onError: (e) => setError(e.message),
+  });
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+    const filtered = options.filter((o) => o.trim());
+    if (filtered.length < 2) { setError("Need at least 2 options."); return; }
+    create.mutate({
+      eventId,
+      groupId,
+      type,
+      question,
+      options: filtered.map((label, i) => ({ label, sortOrder: i })),
+    });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm">Add poll</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader><DialogTitle>Add poll</DialogTitle></DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {error && <p className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">{error}</p>}
+          <div className="space-y-2">
+            <Label>Type</Label>
+            <div className="flex gap-2 flex-wrap">
+              {(["custom", "time_slot", "game"] as const).map((t) => (
+                <button key={t} type="button" onClick={() => setType(t)}
+                  className={`rounded-md border px-3 py-1 text-sm transition-colors ${type === t ? "border-primary bg-primary text-primary-foreground" : "hover:bg-muted"}`}>
+                  {t === "time_slot" ? "Time slot" : t === "game" ? "Game vote" : "Custom"}
+                </button>
+              ))}
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="poll-q">Question</Label>
+            <Input id="poll-q" required value={question} onChange={(e) => setQuestion(e.target.value)} placeholder="e.g. When works for everyone?" />
+          </div>
+          <div className="space-y-2">
+            <Label>Options</Label>
+            {options.map((opt, i) => (
+              <Input key={i} value={opt} placeholder={`Option ${i + 1}`}
+                onChange={(e) => setOptions(options.map((o, j) => j === i ? e.target.value : o))} />
+            ))}
+            <button type="button" onClick={() => setOptions([...options, ""])}
+              className="text-xs text-muted-foreground hover:text-foreground">
+              + Add option
+            </button>
+          </div>
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="outline" onClick={() => setOpen(false)}>Cancel</Button>
+            <Button type="submit" disabled={!question.trim() || create.isPending}>
+              {create.isPending ? "Creating…" : "Create poll"}
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ── Event detail page ─────────────────────────────────────────────────────────
+
+export default function EventDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
+  const router = useRouter();
+  const utils = api.useUtils();
+
+  const { data: me } = api.user.me.useQuery();
+  const { data: event, isLoading } = api.events.get.useQuery({ id });
+  const upsertRsvp = api.events.upsertRsvp.useMutation({
+    onSuccess: () => void utils.events.get.invalidate({ id }),
+  });
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [confirmStart, setConfirmStart] = useState("");
+  const [confirmEnd, setConfirmEnd] = useState("");
+  const [statusError, setStatusError] = useState("");
+  const updateStatus = api.events.updateStatus.useMutation({
+    onSuccess: () => { void utils.events.get.invalidate({ id }); setConfirmOpen(false); },
+    onError: (e) => setStatusError(e.message),
+  });
+
+  if (isLoading) return <p className="text-muted-foreground text-sm">Loading…</p>;
+  if (!event) return <p className="text-muted-foreground text-sm">Event not found.</p>;
+
+  const myUserId = me?.id ?? "";
+  const yesCount = event.rsvps.filter((r) => r.status === "yes").length;
+  const maybeCount = event.rsvps.filter((r) => r.status === "maybe").length;
+  const noCount = event.rsvps.filter((r) => r.status === "no").length;
+  const isEventCreator = event.createdBy.id === myUserId;
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div>
+        <button onClick={() => router.back()} className="text-sm text-muted-foreground hover:text-foreground mb-2">
+          ← Back
+        </button>
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h1 className="text-2xl font-bold">{event.title}</h1>
+            {event.description && <p className="text-muted-foreground mt-1">{event.description}</p>}
+          </div>
+          <Badge variant={event.status === "cancelled" ? "destructive" : event.status === "confirmed" ? "default" : "secondary"}>
+            {STATUS_LABEL[event.status]}
+          </Badge>
+        </div>
+        {event.confirmedStartsAt && (
+          <p className="text-sm text-muted-foreground mt-2">
+            {format(new Date(event.confirmedStartsAt), "EEEE d MMMM, HH:mm")}
+            {event.confirmedEndsAt && ` – ${format(new Date(event.confirmedEndsAt), "HH:mm")}`}
+          </p>
+        )}
+        <p className="text-xs text-muted-foreground mt-1">
+          Created by {event.createdBy.name}
+        </p>
+      </div>
+
+      {/* RSVP */}
+      {event.status !== "cancelled" && (
+        <div className="space-y-2">
+          <p className="text-sm font-medium">Your RSVP</p>
+          <div className="flex gap-2 flex-wrap">
+            {(["yes", "no", "maybe"] as RsvpStatus[]).map((s) => (
+              <Button
+                key={s}
+                size="sm"
+                variant="outline"
+                disabled={upsertRsvp.isPending}
+                onClick={() => upsertRsvp.mutate({ eventId: id, status: s })}
+              >
+                {RSVP_LABELS[s]}
+              </Button>
+            ))}
+          </div>
+          <p className="text-xs text-muted-foreground">
+            {yesCount} going · {maybeCount} maybe · {noCount} not going
+          </p>
+        </div>
+      )}
+
+      {/* RSVP list */}
+      {event.rsvps.length > 0 && (
+        <div className="space-y-2">
+          <p className="text-sm font-medium">RSVPs</p>
+          <ul className="space-y-1">
+            {event.rsvps.map((r) => (
+              <li key={r.user.id} className="flex items-center gap-2 text-sm">
+                <span>{r.user.name}</span>
+                <Badge variant={r.status === "yes" ? "default" : r.status === "no" ? "destructive" : "secondary"} className="text-xs">
+                  {RSVP_LABELS[r.status as RsvpStatus]}
+                </Badge>
+                {r.note && <span className="text-muted-foreground text-xs">· {r.note}</span>}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* Polls */}
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <p className="text-sm font-medium">Polls</p>
+          {event.status !== "cancelled" && (
+            <CreatePollDialog
+              eventId={id}
+              groupId={event.groupId}
+              onCreated={() => void utils.events.get.invalidate({ id })}
+            />
+          )}
+        </div>
+        {event.polls.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No polls yet.</p>
+        ) : (
+          event.polls.map((poll) => (
+            <PollCard
+              key={poll.id}
+              poll={{ ...poll, createdBy: poll.createdBy }}
+              myUserId={myUserId}
+              onVote={() => void utils.events.get.invalidate({ id })}
+            />
+          ))
+        )}
+      </div>
+
+      {/* Status controls (for event creator) */}
+      {isEventCreator && (event.status === "open" || event.status === "draft") && (
+        <div className="border-t pt-4 space-y-2">
+          <p className="text-sm font-medium">Event controls</p>
+          {statusError && (
+            <p className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">{statusError}</p>
+          )}
+          <div className="flex gap-2 flex-wrap">
+            {event.status === "draft" && (
+              <Button size="sm" onClick={() => { setStatusError(""); updateStatus.mutate({ id, status: "open" }); }} disabled={updateStatus.isPending}>
+                Open for RSVPs
+              </Button>
+            )}
+            {event.status === "open" && (
+              <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+                <DialogTrigger asChild>
+                  <Button size="sm">Confirm event</Button>
+                </DialogTrigger>
+                <DialogContent>
+                  <DialogHeader><DialogTitle>Confirm event time</DialogTitle></DialogHeader>
+                  <form
+                    onSubmit={(e) => {
+                      e.preventDefault();
+                      setStatusError("");
+                      updateStatus.mutate({
+                        id,
+                        status: "confirmed",
+                        confirmedStartsAt: confirmStart ? new Date(confirmStart).toISOString() : undefined,
+                        confirmedEndsAt: confirmEnd ? new Date(confirmEnd).toISOString() : undefined,
+                      });
+                    }}
+                    className="space-y-4"
+                  >
+                    <div className="grid grid-cols-2 gap-3">
+                      <div className="space-y-2">
+                        <Label htmlFor="confirm-start">Start time</Label>
+                        <Input id="confirm-start" type="datetime-local" value={confirmStart} onChange={(e) => setConfirmStart(e.target.value)} />
+                      </div>
+                      <div className="space-y-2">
+                        <Label htmlFor="confirm-end">End time (optional)</Label>
+                        <Input id="confirm-end" type="datetime-local" value={confirmEnd} onChange={(e) => setConfirmEnd(e.target.value)} />
+                      </div>
+                    </div>
+                    <div className="flex justify-end gap-2">
+                      <Button type="button" variant="outline" onClick={() => setConfirmOpen(false)}>Cancel</Button>
+                      <Button type="submit" disabled={updateStatus.isPending}>
+                        {updateStatus.isPending ? "Confirming…" : "Confirm"}
+                      </Button>
+                    </div>
+                  </form>
+                </DialogContent>
+              </Dialog>
+            )}
+            {event.status === "open" && (
+              <Button size="sm" variant="destructive" onClick={() => { setStatusError(""); updateStatus.mutate({ id, status: "cancelled" }); }} disabled={updateStatus.isPending}>
+                Cancel event
+              </Button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(app)/events/page.tsx
+++ b/src/app/(app)/events/page.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { api } from "@/trpc/react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { format } from "date-fns";
+
+// ── Status badge ──────────────────────────────────────────────────────────────
+
+const STATUS_VARIANT: Record<string, "default" | "secondary" | "destructive" | "outline"> = {
+  draft: "secondary",
+  open: "default",
+  confirmed: "default",
+  cancelled: "destructive",
+};
+
+const STATUS_LABEL: Record<string, string> = {
+  draft: "Draft",
+  open: "Open",
+  confirmed: "Confirmed",
+  cancelled: "Cancelled",
+};
+
+// ── Create event dialog ───────────────────────────────────────────────────────
+
+function CreateEventDialog({
+  groupId,
+  onCreated,
+}: {
+  groupId: string;
+  onCreated: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [error, setError] = useState("");
+
+  const create = api.events.create.useMutation({
+    onSuccess: () => {
+      setOpen(false);
+      setTitle("");
+      setDescription("");
+      onCreated();
+    },
+    onError: (e) => setError(e.message),
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button>New event</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Create event</DialogTitle>
+        </DialogHeader>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            setError("");
+            create.mutate({ groupId, title, description: description || undefined });
+          }}
+          className="space-y-4"
+        >
+          {error && (
+            <p className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+              {error}
+            </p>
+          )}
+          <div className="space-y-2">
+            <Label htmlFor="event-title">Title</Label>
+            <Input
+              id="event-title"
+              placeholder="e.g. Friday Night Session"
+              required
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="event-desc">Description (optional)</Label>
+            <Input
+              id="event-desc"
+              placeholder="What are you planning?"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+            />
+          </div>
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="outline" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!title.trim() || create.isPending}>
+              {create.isPending ? "Creating…" : "Create"}
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ── Events list for a group ───────────────────────────────────────────────────
+
+function GroupEvents({ groupId, groupName }: { groupId: string; groupName: string }) {
+  const { data: eventList = [], refetch } = api.events.list.useQuery({ groupId });
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h2 className="font-semibold">{groupName}</h2>
+        <CreateEventDialog groupId={groupId} onCreated={() => void refetch()} />
+      </div>
+      {eventList.length === 0 ? (
+        <div className="rounded-lg border border-dashed p-6 text-center">
+          <p className="text-sm text-muted-foreground">No events yet. Create one to get started.</p>
+        </div>
+      ) : (
+        <ul className="space-y-2">
+          {eventList.map((ev) => {
+            const myRsvp = ev.rsvps.find((r) => r.status === "yes")?.status;
+            return (
+              <li key={ev.id}>
+                <Link
+                  href={`/events/${ev.id}`}
+                  className="flex items-center justify-between rounded-lg border p-3 hover:bg-muted/50 transition-colors"
+                >
+                  <div className="space-y-1">
+                    <p className="font-medium">{ev.title}</p>
+                    <div className="flex items-center gap-2">
+                      <Badge variant={STATUS_VARIANT[ev.status]} className="text-xs">
+                        {STATUS_LABEL[ev.status]}
+                      </Badge>
+                      {ev.confirmedStartsAt && (
+                        <span className="text-xs text-muted-foreground">
+                          {format(new Date(ev.confirmedStartsAt), "d MMM, HH:mm")}
+                        </span>
+                      )}
+                      {ev.polls.length > 0 && (
+                        <span className="text-xs text-muted-foreground">
+                          {ev.polls.length} poll{ev.polls.length === 1 ? "" : "s"}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <span className="text-xs text-muted-foreground">
+                      {ev.rsvps.length} RSVP{ev.rsvps.length === 1 ? "" : "s"}
+                    </span>
+                    {myRsvp && (
+                      <Badge variant="outline" className="text-xs">
+                        Going
+                      </Badge>
+                    )}
+                  </div>
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+// ── Main page ─────────────────────────────────────────────────────────────────
+
+export default function EventsPage() {
+  const { data: groups = [] } = api.groups.list.useQuery();
+  const [selectedGroupId, setSelectedGroupId] = useState<string | null>(null);
+
+  const activeGroupId = selectedGroupId ?? groups[0]?.id ?? null;
+
+  if (groups.length === 0) {
+    return (
+      <div className="space-y-4">
+        <h1 className="text-2xl font-bold">Events</h1>
+        <div className="rounded-lg border border-dashed p-8 text-center">
+          <p className="text-sm text-muted-foreground">
+            Join or create a group to start planning events.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold">Events</h1>
+
+      {/* Group tabs */}
+      {groups.length > 1 && (
+        <div className="flex flex-wrap gap-2">
+          {groups.map((g) => (
+            <button
+              key={g.id}
+              onClick={() => setSelectedGroupId(g.id)}
+              className={`rounded-md border px-3 py-1 text-sm transition-colors ${
+                activeGroupId === g.id
+                  ? "border-primary bg-primary text-primary-foreground"
+                  : "hover:bg-muted"
+              }`}
+            >
+              {g.name}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {activeGroupId && (
+        <GroupEvents
+          groupId={activeGroupId}
+          groupName={groups.find((g) => g.id === activeGroupId)?.name ?? ""}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/app/(app)/feed/page.tsx
+++ b/src/app/(app)/feed/page.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { api } from "@/trpc/react";
+import { PostComposer } from "@/components/feed/post-composer";
+import { PostCard } from "@/components/feed/post-card";
+
+export default function FeedPage() {
+  const { data, refetch, isLoading } = api.feed.list.useQuery({ limit: 20 });
+  const { data: me } = api.user.me.useQuery();
+
+  return (
+    <div className="space-y-4 max-w-2xl mx-auto">
+      <PostComposer onPosted={() => void refetch()} />
+
+      {isLoading && <p className="text-sm text-muted-foreground text-center py-8">Loading…</p>}
+
+      {!isLoading && data?.items.length === 0 && (
+        <div className="rounded-lg border border-dashed p-8 text-center">
+          <p className="text-sm text-muted-foreground">
+            Nothing here yet. Add some friends or post something!
+          </p>
+        </div>
+      )}
+
+      {data?.items.map((post) => (
+        <PostCard
+          key={post.id}
+          post={post}
+          currentUserId={me?.id ?? ""}
+          onRefresh={() => void refetch()}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/app/(app)/friends/page.tsx
+++ b/src/app/(app)/friends/page.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import Link from "next/link";
+import { api } from "@/trpc/react";
+import { Button } from "@/components/ui/button";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+
+function initials(name: string) {
+  return name
+    .split(" ")
+    .map((w) => w[0])
+    .join("")
+    .toUpperCase()
+    .slice(0, 2);
+}
+
+export default function FriendsPage() {
+  const { data, refetch } = api.friends.list.useQuery();
+
+  const remove = api.friends.remove.useMutation({
+    onSuccess: () => void refetch(),
+  });
+
+  const friends = data?.friends ?? [];
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">Friends</h1>
+          <p className="text-muted-foreground">
+            {friends.length === 0 ? "No friends yet." : `${friends.length} friend${friends.length === 1 ? "" : "s"}`}
+          </p>
+        </div>
+        <Button asChild variant="outline">
+          <Link href="/people">Find people</Link>
+        </Button>
+      </div>
+
+      {friends.length === 0 ? (
+        <div className="rounded-lg border border-dashed p-8 text-center">
+          <p className="text-sm text-muted-foreground">
+            Search for people to add as friends.
+          </p>
+          <Button asChild className="mt-4">
+            <Link href="/people">Find people</Link>
+          </Button>
+        </div>
+      ) : (
+        <ul className="space-y-2">
+          {friends.map((u) => (
+            <li key={u.id} className="flex items-center justify-between rounded-lg border p-3">
+              <div className="flex items-center gap-3">
+                <Avatar className="h-9 w-9">
+                  <AvatarImage src={u.image ?? undefined} />
+                  <AvatarFallback>{initials(u.name)}</AvatarFallback>
+                </Avatar>
+                <div>
+                  <p className="text-sm font-medium">{u.name}</p>
+                  {u.username && (
+                    <p className="text-xs text-muted-foreground">@{u.username}</p>
+                  )}
+                </div>
+              </div>
+              <Button
+                size="sm"
+                variant="ghost"
+                className="text-muted-foreground hover:text-destructive"
+                onClick={() => remove.mutate({ friendId: u.id })}
+                disabled={remove.isPending}
+              >
+                Remove
+              </Button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/app/(app)/games/page.tsx
+++ b/src/app/(app)/games/page.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import { useState } from "react";
+import { api } from "@/trpc/react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+
+const PLATFORMS = ["pc", "playstation", "xbox", "nintendo", "other"] as const;
+type Platform = (typeof PLATFORMS)[number];
+
+const PLATFORM_LABELS: Record<Platform, string> = {
+  pc: "PC",
+  playstation: "PlayStation",
+  xbox: "Xbox",
+  nintendo: "Nintendo",
+  other: "Other",
+};
+
+// ── Add game dialog ───────────────────────────────────────────────────────────
+
+function AddGameDialog({ onAdded }: { onAdded: () => void }) {
+  const [open, setOpen] = useState(false);
+  const [title, setTitle] = useState("");
+  const [minPlayers, setMinPlayers] = useState("");
+  const [maxPlayers, setMaxPlayers] = useState("");
+  const [platform, setPlatform] = useState<Platform>("pc");
+  const [error, setError] = useState("");
+
+  const create = api.games.create.useMutation();
+  const toggleOwnership = api.games.toggleOwnership.useMutation({
+    onSuccess: () => {
+      setOpen(false);
+      setTitle("");
+      setMinPlayers("");
+      setMaxPlayers("");
+      onAdded();
+    },
+    onError: (err) => setError(err.message),
+  });
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+    const { id } = await create.mutateAsync({
+      title,
+      minPlayers: minPlayers ? parseInt(minPlayers) : undefined,
+      maxPlayers: maxPlayers ? parseInt(maxPlayers) : undefined,
+    });
+    toggleOwnership.mutate({ gameId: id, platform });
+  }
+
+  const isPending = create.isPending || toggleOwnership.isPending;
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button>Add game</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add a game to your library</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {error && (
+            <p className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+              {error}
+            </p>
+          )}
+          <div className="space-y-2">
+            <Label htmlFor="game-title">Title</Label>
+            <Input
+              id="game-title"
+              placeholder="e.g. Elden Ring"
+              required
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+            />
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-2">
+              <Label htmlFor="min-players">Min players</Label>
+              <Input
+                id="min-players"
+                type="number"
+                min={1}
+                placeholder="1"
+                value={minPlayers}
+                onChange={(e) => setMinPlayers(e.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="max-players">Max players</Label>
+              <Input
+                id="max-players"
+                type="number"
+                min={1}
+                placeholder="4"
+                value={maxPlayers}
+                onChange={(e) => setMaxPlayers(e.target.value)}
+              />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label>Platform</Label>
+            <div className="flex flex-wrap gap-2">
+              {PLATFORMS.map((p) => (
+                <button
+                  key={p}
+                  type="button"
+                  onClick={() => setPlatform(p)}
+                  className={`rounded-md border px-3 py-1 text-sm transition-colors ${
+                    platform === p
+                      ? "border-primary bg-primary text-primary-foreground"
+                      : "hover:bg-muted"
+                  }`}
+                >
+                  {PLATFORM_LABELS[p]}
+                </button>
+              ))}
+            </div>
+          </div>
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="outline" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!title.trim() || isPending}>
+              {isPending ? "Adding…" : "Add to library"}
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ── Main page ─────────────────────────────────────────────────────────────────
+
+export default function GamesPage() {
+  const [filterPlatform, setFilterPlatform] = useState<Platform | undefined>();
+  const { data: myGames = [], refetch } = api.games.myGames.useQuery({
+    platform: filterPlatform,
+  });
+
+  const toggleOwnership = api.games.toggleOwnership.useMutation({
+    onSuccess: () => void refetch(),
+  });
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">My Games</h1>
+          <p className="text-muted-foreground">
+            {myGames.length === 0 ? "No games yet." : `${myGames.length} game${myGames.length === 1 ? "" : "s"}`}
+          </p>
+        </div>
+        <AddGameDialog onAdded={() => void refetch()} />
+      </div>
+
+      {/* Platform filter */}
+      <div className="flex flex-wrap gap-2">
+        <button
+          onClick={() => setFilterPlatform(undefined)}
+          className={`rounded-md border px-3 py-1 text-sm transition-colors ${
+            !filterPlatform ? "border-primary bg-primary text-primary-foreground" : "hover:bg-muted"
+          }`}
+        >
+          All
+        </button>
+        {PLATFORMS.map((p) => (
+          <button
+            key={p}
+            onClick={() => setFilterPlatform(filterPlatform === p ? undefined : p)}
+            className={`rounded-md border px-3 py-1 text-sm transition-colors ${
+              filterPlatform === p
+                ? "border-primary bg-primary text-primary-foreground"
+                : "hover:bg-muted"
+            }`}
+          >
+            {PLATFORM_LABELS[p]}
+          </button>
+        ))}
+      </div>
+
+      {myGames.length === 0 ? (
+        <div className="rounded-lg border border-dashed p-8 text-center">
+          <p className="text-sm text-muted-foreground">
+            Add games you own so friends can see what you can play together.
+          </p>
+        </div>
+      ) : (
+        <ul className="space-y-2">
+          {myGames.map((g) => (
+            <li key={`${g.id}-${g.platform}`} className="flex items-center justify-between rounded-lg border p-3">
+              <div className="space-y-1">
+                <p className="font-medium">{g.title}</p>
+                <div className="flex items-center gap-2">
+                  <Badge variant="secondary" className="text-xs">
+                    {PLATFORM_LABELS[g.platform as Platform]}
+                  </Badge>
+                  {g.minPlayers && g.maxPlayers && (
+                    <span className="text-xs text-muted-foreground">
+                      {g.minPlayers}–{g.maxPlayers} players
+                    </span>
+                  )}
+                  {g.genres && g.genres.length > 0 && (
+                    <span className="text-xs text-muted-foreground">{g.genres.join(", ")}</span>
+                  )}
+                </div>
+              </div>
+              <Button
+                size="sm"
+                variant="ghost"
+                className="text-muted-foreground hover:text-destructive"
+                onClick={() =>
+                  toggleOwnership.mutate({ gameId: g.id, platform: g.platform as Platform })
+                }
+                disabled={toggleOwnership.isPending}
+              >
+                Remove
+              </Button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/app/(app)/groups/[id]/page.tsx
+++ b/src/app/(app)/groups/[id]/page.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { use, useState } from "react";
+import { useRouter } from "next/navigation";
+import { api } from "@/trpc/react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+
+function initials(name: string) {
+  return name.split(" ").map((w) => w[0]).join("").toUpperCase().slice(0, 2);
+}
+
+function InviteSection({ groupId }: { groupId: string }) {
+  const [copied, setCopied] = useState(false);
+  const { data } = api.groups.getInviteToken.useQuery({ id: groupId });
+
+  const inviteUrl = data?.inviteToken
+    ? `${typeof window !== "undefined" ? window.location.origin : ""}/join/${data.inviteToken}`
+    : "";
+
+  function handleCopy() {
+    void navigator.clipboard.writeText(inviteUrl);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  return (
+    <div className="space-y-2">
+      <p className="text-sm font-medium">Invite link</p>
+      <div className="flex gap-2">
+        <Input readOnly value={inviteUrl} className="text-xs" />
+        <Button variant="outline" size="sm" onClick={handleCopy} className="shrink-0">
+          {copied ? "Copied!" : "Copy"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export default function GroupPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
+  const router = useRouter();
+  const { data: group, isLoading } = api.groups.get.useQuery({ id });
+
+  const leave = api.groups.leave.useMutation({
+    onSuccess: () => router.push("/groups"),
+    onError: (err) => alert(err.message),
+  });
+
+  if (isLoading) return <p className="text-muted-foreground">Loading…</p>;
+  if (!group) return <p className="text-muted-foreground">Group not found.</p>;
+
+  return (
+    <div className="space-y-8">
+      <div className="flex items-start justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">{group.name}</h1>
+          {group.description && (
+            <p className="mt-1 text-muted-foreground">{group.description}</p>
+          )}
+        </div>
+        {group.myRole !== "owner" && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="text-destructive hover:text-destructive"
+            onClick={() => leave.mutate({ id })}
+            disabled={leave.isPending}
+          >
+            Leave group
+          </Button>
+        )}
+      </div>
+
+      <InviteSection groupId={id} />
+
+      <section className="space-y-3">
+        <h2 className="font-semibold">
+          Members ({group.memberships.length})
+        </h2>
+        <ul className="space-y-2">
+          {group.memberships.map((m) => (
+            <li key={m.userId} className="flex items-center justify-between rounded-lg border p-3">
+              <div className="flex items-center gap-3">
+                <Avatar className="h-9 w-9">
+                  <AvatarImage src={m.user.image ?? undefined} />
+                  <AvatarFallback>{initials(m.user.name)}</AvatarFallback>
+                </Avatar>
+                <div>
+                  <p className="text-sm font-medium">{m.user.name}</p>
+                  {m.user.username && (
+                    <p className="text-xs text-muted-foreground">@{m.user.username}</p>
+                  )}
+                </div>
+              </div>
+              <span className="text-xs text-muted-foreground capitalize">{m.role}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/src/app/(app)/groups/page.tsx
+++ b/src/app/(app)/groups/page.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { api } from "@/trpc/react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+
+function CreateGroupDialog({ onCreated }: { onCreated: () => void }) {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [error, setError] = useState("");
+
+  const create = api.groups.create.useMutation({
+    onSuccess: () => {
+      setOpen(false);
+      setName("");
+      setDescription("");
+      onCreated();
+    },
+    onError: (err) => setError(err.message),
+  });
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+    create.mutate({ name, description });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button>Create group</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Create a group</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {error && (
+            <p className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+              {error}
+            </p>
+          )}
+          <div className="space-y-2">
+            <Label htmlFor="group-name">Name</Label>
+            <Input
+              id="group-name"
+              placeholder="Friday Night Squad"
+              required
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="group-desc">Description <span className="text-muted-foreground">(optional)</span></Label>
+            <Textarea
+              id="group-desc"
+              placeholder="What's this group about?"
+              rows={3}
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+            />
+          </div>
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="outline" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!name.trim() || create.isPending}>
+              {create.isPending ? "Creating…" : "Create"}
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default function GroupsPage() {
+  const { data: myGroups = [], refetch } = api.groups.list.useQuery();
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">Groups</h1>
+          <p className="text-muted-foreground">
+            {myGroups.length === 0 ? "You're not in any groups yet." : `${myGroups.length} group${myGroups.length === 1 ? "" : "s"}`}
+          </p>
+        </div>
+        <CreateGroupDialog onCreated={() => void refetch()} />
+      </div>
+
+      {myGroups.length === 0 ? (
+        <div className="rounded-lg border border-dashed p-8 text-center">
+          <p className="text-sm text-muted-foreground">
+            Create a group or ask a friend to share their invite link.
+          </p>
+        </div>
+      ) : (
+        <ul className="space-y-2">
+          {myGroups.map((g) => (
+            <li key={g.id}>
+              <Link
+                href={`/groups/${g.id}`}
+                className="flex items-center justify-between rounded-lg border p-4 hover:bg-muted/50 transition-colors"
+              >
+                <div>
+                  <p className="font-medium">{g.name}</p>
+                  {g.description && (
+                    <p className="text-sm text-muted-foreground line-clamp-1">{g.description}</p>
+                  )}
+                </div>
+                <span className="text-xs text-muted-foreground capitalize">{g.role}</span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/app/(app)/join/[token]/page.tsx
+++ b/src/app/(app)/join/[token]/page.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { use, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { api } from "@/trpc/react";
+
+export default function JoinPage({ params }: { params: Promise<{ token: string }> }) {
+  const { token } = use(params);
+  const router = useRouter();
+
+  const join = api.groups.join.useMutation({
+    onSuccess: ({ id }) => router.push(`/groups/${id}`),
+    onError: (err) => {
+      alert(err.message);
+      router.push("/groups");
+    },
+  });
+
+  useEffect(() => {
+    join.mutate({ inviteToken: token });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [token]);
+
+  return (
+    <div className="flex min-h-[50vh] items-center justify-center">
+      <p className="text-muted-foreground">Joining group…</p>
+    </div>
+  );
+}

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,0 +1,47 @@
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import { auth } from "@/server/auth";
+import { UserMenu } from "@/components/nav/user-menu";
+import { NotificationBell } from "@/components/nav/notification-bell";
+
+export default async function AppLayout({ children }: { children: React.ReactNode }) {
+  let session;
+  try {
+    session = await auth.api.getSession({ headers: await headers() });
+  } catch {
+    redirect("/login");
+  }
+
+  if (!session) {
+    redirect("/login");
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col">
+      <header className="border-b">
+        <div className="mx-auto flex h-14 max-w-4xl items-center justify-between px-4">
+          <div className="flex items-center gap-6">
+            <Link href="/feed" className="text-lg font-semibold tracking-tight">
+              Campfire
+            </Link>
+            <nav className="flex items-center gap-4 text-sm text-muted-foreground">
+              <Link href="/feed" className="hover:text-foreground">Feed</Link>
+              <Link href="/groups" className="hover:text-foreground">Groups</Link>
+              <Link href="/friends" className="hover:text-foreground">Friends</Link>
+              <Link href="/games" className="hover:text-foreground">Games</Link>
+              <Link href="/availability" className="hover:text-foreground">Availability</Link>
+              <Link href="/events" className="hover:text-foreground">Events</Link>
+              <Link href="/people" className="hover:text-foreground">Find people</Link>
+            </nav>
+          </div>
+          <div className="flex items-center gap-4">
+            <NotificationBell />
+            <UserMenu name={session.user.name} />
+          </div>
+        </div>
+      </header>
+      <main className="mx-auto w-full max-w-4xl flex-1 px-4 py-6">{children}</main>
+    </div>
+  );
+}

--- a/src/app/(app)/notifications/page.tsx
+++ b/src/app/(app)/notifications/page.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useEffect } from "react";
+import { formatDistanceToNow } from "date-fns";
+import { api } from "@/trpc/react";
+import { Button } from "@/components/ui/button";
+
+type NotifData = Record<string, string>;
+
+function FriendRequestActions({
+  requesterId,
+  notifId,
+  onDone,
+}: {
+  requesterId: string;
+  notifId: string;
+  onDone: () => void;
+}) {
+  const respond = api.friends.respondToRequest.useMutation({ onSuccess: onDone });
+  const markRead = api.notifications.markRead.useMutation({ onSuccess: onDone });
+
+  function handle(accept: boolean) {
+    respond.mutate({ requesterId, accept });
+    markRead.mutate({ id: notifId });
+  }
+
+  return (
+    <div className="flex gap-2 shrink-0">
+      <Button size="sm" onClick={() => handle(true)} disabled={respond.isPending}>
+        Accept
+      </Button>
+      <Button size="sm" variant="outline" onClick={() => handle(false)} disabled={respond.isPending}>
+        Decline
+      </Button>
+    </div>
+  );
+}
+
+function notifMessage(type: string, data: NotifData): string {
+  switch (type) {
+    case "friend_request_received":
+      return `${data.requesterName ?? "Someone"} sent you a friend request.`;
+    case "friend_request_accepted":
+      return `${data.acceptorName ?? "Someone"} accepted your friend request.`;
+    case "group_invite_received":
+      return `You were invited to join ${data.groupName ?? "a group"}.`;
+    default:
+      return "You have a new notification.";
+  }
+}
+
+export default function NotificationsPage() {
+  const { data: notifs = [], refetch } = api.notifications.list.useQuery({ limit: 50 });
+  const utils = api.useUtils();
+  const markAll = api.notifications.markAllRead.useMutation({
+    onSuccess: () => {
+      void refetch();
+      void utils.notifications.unreadCount.invalidate();
+    },
+  });
+  const markOne = api.notifications.markRead.useMutation({ onSuccess: () => void refetch() });
+
+  // Auto-mark all read on page load — clears the bell badge
+  useEffect(() => {
+    markAll.mutate();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const unreadCount = notifs.filter((n) => !n.readAt).length;
+
+  return (
+    <div className="max-w-2xl mx-auto space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">Notifications</h1>
+          {unreadCount > 0 && (
+            <p className="text-sm text-muted-foreground">{unreadCount} unread</p>
+          )}
+        </div>
+      </div>
+
+      {notifs.length === 0 && (
+        <div className="rounded-lg border border-dashed p-8 text-center">
+          <p className="text-sm text-muted-foreground">No notifications yet.</p>
+        </div>
+      )}
+
+      <ul className="space-y-1">
+        {notifs.map((n) => {
+          const data = n.data as NotifData;
+          const isPendingRequest = n.type === "friend_request_received" && !n.readAt;
+          return (
+            <li
+              key={n.id}
+              className={`flex items-start justify-between gap-4 rounded-lg border p-3 ${!n.readAt ? "bg-muted/40" : ""}`}
+            >
+              <div className="space-y-0.5">
+                <p className={`text-sm ${!n.readAt ? "font-medium" : ""}`}>
+                  {notifMessage(n.type, data)}
+                </p>
+                <p
+                  className="text-xs text-muted-foreground"
+                  title={new Date(n.createdAt).toLocaleString()}
+                >
+                  {formatDistanceToNow(new Date(n.createdAt), { addSuffix: true })}
+                </p>
+              </div>
+              {isPendingRequest && data.requesterId ? (
+                <FriendRequestActions
+                  requesterId={data.requesterId}
+                  notifId={n.id}
+                  onDone={() => void refetch()}
+                />
+              ) : !n.readAt ? (
+                <button
+                  className="shrink-0 text-xs text-muted-foreground hover:text-foreground"
+                  onClick={() => markOne.mutate({ id: n.id })}
+                >
+                  Dismiss
+                </button>
+              ) : null}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/src/app/(app)/onboarding/page.tsx
+++ b/src/app/(app)/onboarding/page.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { api } from "@/trpc/react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+// ── Step 1: Pick a username ───────────────────────────────────────────────────
+
+function StepUsername({ onDone }: { onDone: () => void }) {
+  const [username, setUsername] = useState("");
+  const [error, setError] = useState("");
+
+  const setUsernameMutation = api.user.setUsername.useMutation({
+    onSuccess: onDone,
+    onError: (err) => setError(err.message),
+  });
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+    setUsernameMutation.mutate({ username });
+  }
+
+  const isValid = /^[a-z0-9_]{3,20}$/.test(username);
+
+  return (
+    <Card className="w-full max-w-sm">
+      <CardHeader>
+        <CardTitle>Choose your username</CardTitle>
+        <CardDescription>
+          This is your unique handle on Campfire. You can change it once every 30 days.
+        </CardDescription>
+      </CardHeader>
+      <form onSubmit={handleSubmit}>
+        <CardContent className="space-y-4">
+          {error && (
+            <p className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+              {error}
+            </p>
+          )}
+          <div className="space-y-2">
+            <Label htmlFor="username">Username</Label>
+            <div className="flex items-center gap-1">
+              <span className="text-muted-foreground">@</span>
+              <Input
+                id="username"
+                type="text"
+                placeholder="yourname"
+                autoComplete="off"
+                spellCheck={false}
+                value={username}
+                onChange={(e) => setUsername(e.target.value.toLowerCase().replace(/[^a-z0-9_]/g, ""))}
+              />
+            </div>
+            <p className="text-xs text-muted-foreground">
+              3–20 characters. Letters, numbers, underscores only.
+            </p>
+          </div>
+        </CardContent>
+        <CardFooter>
+          <Button
+            type="submit"
+            className="w-full"
+            disabled={!isValid || setUsernameMutation.isPending}
+          >
+            {setUsernameMutation.isPending ? "Saving…" : "Continue"}
+          </Button>
+        </CardFooter>
+      </form>
+    </Card>
+  );
+}
+
+// ── Step 2: Display name (already set at register, just confirm / skip) ───────
+
+function StepProfile({ onDone }: { onDone: () => void }) {
+  return (
+    <Card className="w-full max-w-sm">
+      <CardHeader>
+        <CardTitle>Your profile</CardTitle>
+        <CardDescription>
+          You can update your display name and add an avatar in your profile settings later.
+        </CardDescription>
+      </CardHeader>
+      <CardFooter>
+        <Button className="w-full" onClick={onDone}>
+          Continue
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}
+
+// ── Step 3: Invite friends ────────────────────────────────────────────────────
+
+function StepInvite({ onDone }: { onDone: () => void }) {
+  const [copied, setCopied] = useState(false);
+  const inviteUrl =
+    typeof window !== "undefined"
+      ? `${window.location.origin}/invite` // placeholder until invite tokens are built
+      : "";
+
+  function handleCopy() {
+    void navigator.clipboard.writeText(inviteUrl);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  return (
+    <Card className="w-full max-w-sm">
+      <CardHeader>
+        <CardTitle>Invite your friends</CardTitle>
+        <CardDescription>
+          Campfire is invite-only. Share your link to get your group started.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="flex gap-2">
+          <Input readOnly value={inviteUrl} className="text-xs" />
+          <Button variant="outline" onClick={handleCopy} className="shrink-0">
+            {copied ? "Copied!" : "Copy"}
+          </Button>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Invite links will be personalised once the feature is fully set up.
+        </p>
+      </CardContent>
+      <CardFooter>
+        <Button className="w-full" onClick={onDone}>
+          Go to feed
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}
+
+// ── Onboarding shell ──────────────────────────────────────────────────────────
+
+const STEPS = ["username", "profile", "invite"] as const;
+type Step = (typeof STEPS)[number];
+
+const STEP_LABELS: Record<Step, string> = {
+  username: "Username",
+  profile: "Profile",
+  invite: "Invite",
+};
+
+export default function OnboardingPage() {
+  const router = useRouter();
+  const [step, setStep] = useState<Step>("username");
+
+  const stepIndex = STEPS.indexOf(step);
+
+  function next() {
+    const nextStep = STEPS[stepIndex + 1];
+    if (nextStep) {
+      setStep(nextStep);
+    } else {
+      router.push("/feed");
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-6 px-4">
+      {/* Progress indicator */}
+      <div className="flex items-center gap-2">
+        {STEPS.map((s, i) => (
+          <div key={s} className="flex items-center gap-2">
+            <div
+              className={`flex h-7 w-7 items-center justify-center rounded-full text-xs font-medium ${
+                i < stepIndex
+                  ? "bg-primary text-primary-foreground"
+                  : i === stepIndex
+                    ? "border-2 border-primary text-primary"
+                    : "border border-muted-foreground/30 text-muted-foreground"
+              }`}
+            >
+              {i + 1}
+            </div>
+            <span
+              className={`text-sm ${i === stepIndex ? "font-medium" : "text-muted-foreground"}`}
+            >
+              {STEP_LABELS[s]}
+            </span>
+            {i < STEPS.length - 1 && (
+              <div className="h-px w-6 bg-muted-foreground/20" />
+            )}
+          </div>
+        ))}
+      </div>
+
+      {step === "username" && <StepUsername onDone={next} />}
+      {step === "profile" && <StepProfile onDone={next} />}
+      {step === "invite" && <StepInvite onDone={next} />}
+    </div>
+  );
+}

--- a/src/app/(app)/people/page.tsx
+++ b/src/app/(app)/people/page.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useState } from "react";
+import { api } from "@/trpc/react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+
+function initials(name: string) {
+  return name
+    .split(" ")
+    .map((w) => w[0])
+    .join("")
+    .toUpperCase()
+    .slice(0, 2);
+}
+
+export default function PeoplePage() {
+  const [query, setQuery] = useState("");
+  const [submitted, setSubmitted] = useState("");
+
+  const search = api.friends.search.useQuery(
+    { query: submitted },
+    { enabled: submitted.length > 0 }
+  );
+
+  const { data: friendData, refetch: refetchFriends } = api.friends.list.useQuery();
+
+  const sendRequest = api.friends.sendRequest.useMutation({
+    onSuccess: () => void refetchFriends(),
+  });
+
+  const respond = api.friends.respondToRequest.useMutation({
+    onSuccess: () => void refetchFriends(),
+  });
+
+  const outgoingIds = new Set(friendData?.outgoing.map((u) => u.id) ?? []);
+  const friendIds = new Set(friendData?.friends.map((u) => u.id) ?? []);
+
+  function handleSearch(e: React.FormEvent) {
+    e.preventDefault();
+    setSubmitted(query.trim());
+  }
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h1 className="text-2xl font-bold">Find people</h1>
+        <p className="text-muted-foreground">Search for friends by username or display name.</p>
+      </div>
+
+      {/* Incoming requests */}
+      {(friendData?.incoming ?? []).length > 0 && (
+        <section className="space-y-3">
+          <h2 className="font-semibold">Friend requests</h2>
+          <ul className="space-y-2">
+            {friendData!.incoming.map((u) => (
+              <li key={u.id} className="flex items-center justify-between rounded-lg border p-3">
+                <div className="flex items-center gap-3">
+                  <Avatar className="h-9 w-9">
+                    <AvatarImage src={u.image ?? undefined} />
+                    <AvatarFallback>{initials(u.name)}</AvatarFallback>
+                  </Avatar>
+                  <div>
+                    <p className="text-sm font-medium">{u.name}</p>
+                    {u.username && <p className="text-xs text-muted-foreground">@{u.username}</p>}
+                  </div>
+                </div>
+                <div className="flex gap-2">
+                  <Button
+                    size="sm"
+                    onClick={() => respond.mutate({ requesterId: u.id, accept: true })}
+                    disabled={respond.isPending}
+                  >
+                    Accept
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => respond.mutate({ requesterId: u.id, accept: false })}
+                    disabled={respond.isPending}
+                  >
+                    Decline
+                  </Button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {/* Search */}
+      <section className="space-y-4">
+        <form onSubmit={handleSearch} className="flex gap-2">
+          <Input
+            placeholder="Search by name or @username"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            className="max-w-sm"
+          />
+          <Button type="submit" disabled={!query.trim()}>
+            Search
+          </Button>
+        </form>
+
+        {search.isFetching && <p className="text-sm text-muted-foreground">Searching…</p>}
+
+        {search.data && search.data.length === 0 && (
+          <p className="text-sm text-muted-foreground">No results for &ldquo;{submitted}&rdquo;.</p>
+        )}
+
+        {search.data && search.data.length > 0 && (
+          <ul className="space-y-2">
+            {search.data.map((u) => {
+              const isFriend = friendIds.has(u.id);
+              const isPending = outgoingIds.has(u.id);
+              return (
+                <li key={u.id} className="flex items-center justify-between rounded-lg border p-3">
+                  <div className="flex items-center gap-3">
+                    <Avatar className="h-9 w-9">
+                      <AvatarImage src={u.image ?? undefined} />
+                      <AvatarFallback>{initials(u.name)}</AvatarFallback>
+                    </Avatar>
+                    <div>
+                      <p className="text-sm font-medium">{u.name}</p>
+                      {u.username && (
+                        <p className="text-xs text-muted-foreground">@{u.username}</p>
+                      )}
+                    </div>
+                  </div>
+                  {isFriend ? (
+                    <span className="text-xs text-muted-foreground">Friends</span>
+                  ) : isPending ? (
+                    <span className="text-xs text-muted-foreground">Request sent</span>
+                  ) : (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => sendRequest.mutate({ addresseeId: u.id })}
+                      disabled={sendRequest.isPending}
+                    >
+                      Add friend
+                    </Button>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -1,0 +1,261 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { api } from "@/trpc/react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type { NotificationPrefs } from "@/server/db/schema";
+
+// ── Toggle row ────────────────────────────────────────────────────────────────
+
+function ToggleRow({
+  label,
+  description,
+  checked,
+  onChange,
+  disabled,
+}: {
+  label: string;
+  description?: string;
+  checked: boolean;
+  onChange: (v: boolean) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <div className="flex items-start justify-between gap-4 py-3">
+      <div>
+        <p className="text-sm font-medium">{label}</p>
+        {description && <p className="text-xs text-muted-foreground mt-0.5">{description}</p>}
+      </div>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        disabled={disabled}
+        onClick={() => onChange(!checked)}
+        className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus-visible:outline-none disabled:opacity-50 ${
+          checked ? "bg-primary" : "bg-input"
+        }`}
+      >
+        <span
+          className={`pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg transition-transform ${
+            checked ? "translate-x-4" : "translate-x-0"
+          }`}
+        />
+      </button>
+    </div>
+  );
+}
+
+// ── Defaults ──────────────────────────────────────────────────────────────────
+
+const PREF_DEFAULTS: Required<NotificationPrefs> = {
+  friendRequestReceived: true,
+  friendRequestAccepted: true,
+  groupInviteReceived: true,
+  emailFriendRequest: false,
+  emailEventConfirmed: true,
+  emailEventCancelled: true,
+  emailEventRsvpReminder: true,
+  emailPollOpened: true,
+  emailPollClosed: false,
+  emailGroupInvite: true,
+};
+
+function mergePrefs(saved: NotificationPrefs | undefined): Required<NotificationPrefs> {
+  return { ...PREF_DEFAULTS, ...(saved ?? {}) };
+}
+
+// ── Settings page ─────────────────────────────────────────────────────────────
+
+export default function SettingsPage() {
+  const { data: me } = api.user.me.useQuery();
+
+  // ── Profile ──────────────────────────────────────────────────────────────────
+  const [displayName, setDisplayName] = useState("");
+  const [username, setUsername] = useState("");
+  const [profileSaved, setProfileSaved] = useState(false);
+  const [profileError, setProfileError] = useState("");
+
+  const setUsernameMutation = api.user.setUsername.useMutation({
+    onSuccess: () => { setProfileSaved(true); setTimeout(() => setProfileSaved(false), 2500); },
+    onError: (e) => setProfileError(e.message),
+  });
+
+  useEffect(() => {
+    if (me) {
+      setDisplayName(me.name ?? "");
+      setUsername(me.username ?? "");
+    }
+  }, [me]);
+
+  // ── Notification prefs ────────────────────────────────────────────────────
+  const [prefs, setPrefs] = useState<Required<NotificationPrefs>>(PREF_DEFAULTS);
+  const [prefsSaved, setPrefsSaved] = useState(false);
+
+  useEffect(() => {
+    if (me) setPrefs(mergePrefs(me.notificationPrefs as NotificationPrefs | undefined));
+  }, [me]);
+
+  const updatePrefs = api.user.updateNotificationPrefs.useMutation({
+    onSuccess: () => { setPrefsSaved(true); setTimeout(() => setPrefsSaved(false), 2500); },
+  });
+
+  function setPref(key: keyof NotificationPrefs, value: boolean) {
+    const next = { ...prefs, [key]: value };
+    setPrefs(next);
+    updatePrefs.mutate({ [key]: value });
+  }
+
+  return (
+    <div className="space-y-8 max-w-xl">
+      <h1 className="text-2xl font-bold">Settings</h1>
+
+      {/* ── Profile ─────────────────────────────────────────────────────────── */}
+      <section className="space-y-4">
+        <h2 className="text-base font-semibold border-b pb-2">Profile</h2>
+
+        <div className="space-y-2">
+          <Label htmlFor="display-name">Display name</Label>
+          <Input
+            id="display-name"
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+            placeholder="Your name"
+          />
+          <p className="text-xs text-muted-foreground">
+            Changing your display name isn&apos;t saved yet — full profile editing coming soon.
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="username">Username</Label>
+          <div className="flex gap-2">
+            <Input
+              id="username"
+              value={username}
+              onChange={(e) => { setUsername(e.target.value); setProfileError(""); setProfileSaved(false); }}
+              placeholder="your_handle"
+            />
+            <Button
+              onClick={() => { setProfileError(""); setUsernameMutation.mutate({ username }); }}
+              disabled={!username.trim() || setUsernameMutation.isPending}
+            >
+              {setUsernameMutation.isPending ? "Saving…" : "Save"}
+            </Button>
+          </div>
+          {profileError && <p className="text-xs text-destructive">{profileError}</p>}
+          {profileSaved && <p className="text-xs text-green-600">Username saved!</p>}
+          <p className="text-xs text-muted-foreground">3–20 chars, lowercase letters, numbers and underscores only.</p>
+        </div>
+
+        <div className="space-y-1">
+          <Label>Email</Label>
+          <p className="text-sm text-muted-foreground">{me?.email ?? "—"}</p>
+        </div>
+      </section>
+
+      {/* ── Notifications ────────────────────────────────────────────────────── */}
+      <section className="space-y-1">
+        <div className="flex items-center justify-between border-b pb-2">
+          <h2 className="text-base font-semibold">Notifications</h2>
+          {prefsSaved && <span className="text-xs text-green-600">Saved</span>}
+        </div>
+
+        <div className="space-y-1">
+          <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide pt-3 pb-1">
+            In-app alerts
+          </p>
+          <div className="divide-y">
+            <ToggleRow
+              label="Friend request received"
+              checked={prefs.friendRequestReceived}
+              onChange={(v) => setPref("friendRequestReceived", v)}
+              disabled={updatePrefs.isPending}
+            />
+            <ToggleRow
+              label="Friend request accepted"
+              checked={prefs.friendRequestAccepted}
+              onChange={(v) => setPref("friendRequestAccepted", v)}
+              disabled={updatePrefs.isPending}
+            />
+            <ToggleRow
+              label="Group invite received"
+              checked={prefs.groupInviteReceived}
+              onChange={(v) => setPref("groupInviteReceived", v)}
+              disabled={updatePrefs.isPending}
+            />
+          </div>
+
+          <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide pt-4 pb-1">
+            Email — Events
+          </p>
+          <div className="divide-y">
+            <ToggleRow
+              label="Event confirmed"
+              description="When an event you RSVP'd to is confirmed with a time."
+              checked={prefs.emailEventConfirmed}
+              onChange={(v) => setPref("emailEventConfirmed", v)}
+              disabled={updatePrefs.isPending}
+            />
+            <ToggleRow
+              label="Event cancelled"
+              description="When an event you RSVP'd to is cancelled."
+              checked={prefs.emailEventCancelled}
+              onChange={(v) => setPref("emailEventCancelled", v)}
+              disabled={updatePrefs.isPending}
+            />
+            <ToggleRow
+              label="RSVP reminder"
+              description="A reminder before an event if you haven't RSVP'd yet."
+              checked={prefs.emailEventRsvpReminder}
+              onChange={(v) => setPref("emailEventRsvpReminder", v)}
+              disabled={updatePrefs.isPending}
+            />
+          </div>
+
+          <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide pt-4 pb-1">
+            Email — Polls
+          </p>
+          <div className="divide-y">
+            <ToggleRow
+              label="Poll opened"
+              description="When a new poll is opened in a group you're in."
+              checked={prefs.emailPollOpened}
+              onChange={(v) => setPref("emailPollOpened", v)}
+              disabled={updatePrefs.isPending}
+            />
+            <ToggleRow
+              label="Poll closed"
+              description="When a poll you voted on is closed."
+              checked={prefs.emailPollClosed}
+              onChange={(v) => setPref("emailPollClosed", v)}
+              disabled={updatePrefs.isPending}
+            />
+          </div>
+
+          <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide pt-4 pb-1">
+            Email — Social
+          </p>
+          <div className="divide-y">
+            <ToggleRow
+              label="Group invite"
+              description="When someone invites you to a group."
+              checked={prefs.emailGroupInvite}
+              onChange={(v) => setPref("emailGroupInvite", v)}
+              disabled={updatePrefs.isPending}
+            />
+            <ToggleRow
+              label="Friend request"
+              description="When someone sends you a friend request."
+              checked={prefs.emailFriendRequest}
+              onChange={(v) => setPref("emailFriendRequest", v)}
+              disabled={updatePrefs.isPending}
+            />
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { authClient } from "@/lib/auth-client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+export default function ForgotPasswordPage() {
+  const [email, setEmail] = useState("");
+  const [sent, setSent] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    await authClient.requestPasswordReset({
+      email,
+      redirectTo: "/reset-password",
+    });
+    // Always show success to avoid email enumeration
+    setSent(true);
+    setLoading(false);
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center px-4">
+      <Card className="w-full max-w-sm">
+        <CardHeader>
+          <CardTitle className="text-2xl">Forgot password</CardTitle>
+          <CardDescription>
+            Enter your email and we&apos;ll send a reset link
+          </CardDescription>
+        </CardHeader>
+        {sent ? (
+          <CardContent>
+            <p className="text-sm text-muted-foreground">
+              If an account exists for <strong>{email}</strong>, a reset link is on its
+              way. Check your inbox (and spam folder).
+            </p>
+          </CardContent>
+        ) : (
+          <form onSubmit={handleSubmit}>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="email">Email</Label>
+                <Input
+                  id="email"
+                  type="email"
+                  placeholder="you@example.com"
+                  autoComplete="email"
+                  required
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                />
+              </div>
+            </CardContent>
+            <CardFooter>
+              <Button type="submit" className="w-full" disabled={loading}>
+                {loading ? "Sending…" : "Send reset link"}
+              </Button>
+            </CardFooter>
+          </form>
+        )}
+        <CardFooter>
+          <p className="text-center text-sm text-muted-foreground w-full">
+            <Link
+              href="/login"
+              className="underline underline-offset-4 hover:text-foreground"
+            >
+              Back to sign in
+            </Link>
+          </p>
+        </CardFooter>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,0 +1,5 @@
+// Auth pages (login, register, forgot-password) share this layout.
+// No nav — just a clean centered shell.
+export default function AuthLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { authClient } from "@/lib/auth-client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+export default function LoginPage() {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+
+    const { error } = await authClient.signIn.email({
+      email,
+      password,
+    });
+
+    if (error) {
+      setError(error.message ?? "Invalid email or password.");
+      setLoading(false);
+      return;
+    }
+
+    router.push("/feed");
+    router.refresh();
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center px-4">
+      <Card className="w-full max-w-sm">
+        <CardHeader>
+          <CardTitle className="text-2xl">Sign in</CardTitle>
+          <CardDescription>Welcome back to Campfire</CardDescription>
+        </CardHeader>
+        <form onSubmit={handleSubmit}>
+          <CardContent className="space-y-4">
+            {error && (
+              <p className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                {error}
+              </p>
+            )}
+            <div className="space-y-2">
+              <Label htmlFor="email">Email</Label>
+              <Input
+                id="email"
+                type="email"
+                placeholder="you@example.com"
+                autoComplete="email"
+                required
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <Label htmlFor="password">Password</Label>
+                <Link
+                  href="/forgot-password"
+                  className="text-sm text-muted-foreground underline-offset-4 hover:underline"
+                >
+                  Forgot password?
+                </Link>
+              </div>
+              <Input
+                id="password"
+                type="password"
+                autoComplete="current-password"
+                required
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+              />
+            </div>
+          </CardContent>
+          <CardFooter className="flex flex-col gap-3">
+            <Button type="submit" className="w-full" disabled={loading}>
+              {loading ? "Signing in…" : "Sign in"}
+            </Button>
+            <p className="text-center text-sm text-muted-foreground">
+              Don&apos;t have an account?{" "}
+              <Link
+                href="/register"
+                className="underline underline-offset-4 hover:text-foreground"
+              >
+                Register
+              </Link>
+            </p>
+          </CardFooter>
+        </form>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { authClient } from "@/lib/auth-client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+export default function RegisterPage() {
+  const router = useRouter();
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+
+    const { error } = await authClient.signUp.email({
+      name,
+      email,
+      password,
+    });
+
+    if (error) {
+      setError(error.message ?? "Could not create account. Please try again.");
+      setLoading(false);
+      return;
+    }
+
+    // After sign-up, redirect to onboarding to set username
+    router.push("/onboarding");
+    router.refresh();
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center px-4">
+      <Card className="w-full max-w-sm">
+        <CardHeader>
+          <CardTitle className="text-2xl">Create account</CardTitle>
+          <CardDescription>Join Campfire and start planning sessions</CardDescription>
+        </CardHeader>
+        <form onSubmit={handleSubmit}>
+          <CardContent className="space-y-4">
+            {error && (
+              <p className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                {error}
+              </p>
+            )}
+            <div className="space-y-2">
+              <Label htmlFor="name">Display name</Label>
+              <Input
+                id="name"
+                type="text"
+                placeholder="Your name"
+                autoComplete="name"
+                required
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="email">Email</Label>
+              <Input
+                id="email"
+                type="email"
+                placeholder="you@example.com"
+                autoComplete="email"
+                required
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="password">Password</Label>
+              <Input
+                id="password"
+                type="password"
+                autoComplete="new-password"
+                required
+                minLength={8}
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+              />
+              <p className="text-xs text-muted-foreground">Minimum 8 characters</p>
+            </div>
+          </CardContent>
+          <CardFooter className="flex flex-col gap-3">
+            <Button type="submit" className="w-full" disabled={loading}>
+              {loading ? "Creating account…" : "Create account"}
+            </Button>
+            <p className="text-center text-sm text-muted-foreground">
+              Already have an account?{" "}
+              <Link
+                href="/login"
+                className="underline underline-offset-4 hover:text-foreground"
+              >
+                Sign in
+              </Link>
+            </p>
+          </CardFooter>
+        </form>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,8 @@
-export default function HomePage() {
-  return (
-    <main className="flex min-h-screen flex-col items-center justify-center gap-4">
-      <h1 className="text-4xl font-bold tracking-tight">Campfire</h1>
-      <p className="text-muted-foreground">Play together. Plan together.</p>
-    </main>
-  );
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+import { auth } from "@/server/auth";
+
+export default async function RootPage() {
+  const session = await auth.api.getSession({ headers: await headers() });
+  redirect(session ? "/feed" : "/login");
 }

--- a/src/components/feed/post-card.tsx
+++ b/src/components/feed/post-card.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { useState } from "react";
+import { formatDistanceToNow } from "date-fns";
+import { api } from "@/trpc/react";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+
+function initials(name: string) {
+  return name.split(" ").map((w) => w[0]).join("").toUpperCase().slice(0, 2);
+}
+
+type PostAuthor = { id: string; name: string; username: string | null; image: string | null };
+type CommentData = {
+  id: string;
+  body: string;
+  createdAt: Date;
+  deletedAt: Date | null;
+  author: PostAuthor;
+  reactions: { id: string; userId: string }[];
+};
+type PostData = {
+  id: string;
+  body: string | null;
+  createdAt: Date;
+  editedAt: Date | null;
+  deletedAt: Date | null;
+  author: PostAuthor;
+  group: { id: string; name: string } | null;
+  reactions: { id: string; userId: string; type: string }[];
+  comments: CommentData[];
+};
+
+function CommentRow({
+  comment,
+  currentUserId,
+  onDeleted,
+}: {
+  comment: CommentData;
+  currentUserId: string;
+  onDeleted: () => void;
+}) {
+  const deleteComment = api.feed.deleteComment.useMutation({ onSuccess: onDeleted });
+
+  return (
+    <div className="flex gap-2">
+      <Avatar className="h-7 w-7 shrink-0">
+        <AvatarImage src={comment.author.image ?? undefined} />
+        <AvatarFallback className="text-xs">{initials(comment.author.name)}</AvatarFallback>
+      </Avatar>
+      <div className="flex-1 space-y-0.5">
+        <div className="rounded-lg bg-muted px-3 py-2 text-sm">
+          <span className="font-medium">{comment.author.name}</span>{" "}
+          {comment.body}
+        </div>
+        <div className="flex items-center gap-2 px-1">
+          <span
+            className="text-xs text-muted-foreground"
+            title={new Date(comment.createdAt).toLocaleString()}
+          >
+            {formatDistanceToNow(new Date(comment.createdAt), { addSuffix: true })}
+          </span>
+          {comment.author.id === currentUserId && (
+            <button
+              className="text-xs text-muted-foreground hover:text-destructive"
+              onClick={() => deleteComment.mutate({ id: comment.id })}
+            >
+              Delete
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function PostCard({
+  post,
+  currentUserId,
+  onRefresh,
+}: {
+  post: PostData;
+  currentUserId: string;
+  onRefresh: () => void;
+}) {
+  const [showComments, setShowComments] = useState(false);
+  const [commentBody, setCommentBody] = useState("");
+
+  const toggleLike = api.feed.toggleLike.useMutation({ onSuccess: onRefresh });
+  const deletePost = api.feed.delete.useMutation({ onSuccess: onRefresh });
+  const addComment = api.feed.comment.useMutation({
+    onSuccess: () => {
+      setCommentBody("");
+      onRefresh();
+    },
+  });
+
+  const likeCount = post.reactions.filter((r) => r.type === "like").length;
+  const hasLiked = post.reactions.some((r) => r.userId === currentUserId);
+  const commentCount = post.comments.length;
+
+  return (
+    <article className="space-y-3 rounded-lg border p-4">
+      {/* Header */}
+      <div className="flex items-start justify-between">
+        <div className="flex items-center gap-2">
+          <Avatar className="h-9 w-9">
+            <AvatarImage src={post.author.image ?? undefined} />
+            <AvatarFallback>{initials(post.author.name)}</AvatarFallback>
+          </Avatar>
+          <div>
+            <p className="text-sm font-medium leading-none">{post.author.name}</p>
+            <p className="text-xs text-muted-foreground">
+              {post.author.username ? `@${post.author.username} · ` : ""}
+              {formatDistanceToNow(new Date(post.createdAt), { addSuffix: true })}
+              {post.group && (
+                <> · <span className="font-medium">{post.group.name}</span></>
+              )}
+            </p>
+          </div>
+        </div>
+        {post.author.id === currentUserId && (
+          <button
+            className="text-xs text-muted-foreground hover:text-destructive"
+            onClick={() => deletePost.mutate({ id: post.id })}
+          >
+            Delete
+          </button>
+        )}
+      </div>
+
+      {/* Body */}
+      {post.body && <p className="text-sm whitespace-pre-wrap">{post.body}</p>}
+
+      {/* Actions */}
+      <div className="flex items-center gap-4 border-t pt-2">
+        <button
+          className={`flex items-center gap-1 text-sm ${hasLiked ? "text-primary font-medium" : "text-muted-foreground hover:text-foreground"}`}
+          onClick={() => toggleLike.mutate({ postId: post.id })}
+        >
+          {hasLiked ? "♥" : "♡"} {likeCount > 0 && likeCount}
+        </button>
+        <button
+          className="text-sm text-muted-foreground hover:text-foreground"
+          onClick={() => setShowComments((v) => !v)}
+        >
+          💬 {commentCount > 0 && commentCount}
+        </button>
+      </div>
+
+      {/* Comments */}
+      {showComments && (
+        <div className="space-y-3 border-t pt-3">
+          {post.comments.map((c) => (
+            <CommentRow
+              key={c.id}
+              comment={c}
+              currentUserId={currentUserId}
+              onDeleted={onRefresh}
+            />
+          ))}
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              if (commentBody.trim()) addComment.mutate({ postId: post.id, body: commentBody.trim() });
+            }}
+            className="flex gap-2"
+          >
+            <Textarea
+              placeholder="Write a comment…"
+              rows={1}
+              value={commentBody}
+              onChange={(e) => setCommentBody(e.target.value)}
+              className="min-h-0 resize-none"
+            />
+            <Button type="submit" size="sm" disabled={!commentBody.trim() || addComment.isPending}>
+              Send
+            </Button>
+          </form>
+        </div>
+      )}
+    </article>
+  );
+}

--- a/src/components/feed/post-composer.tsx
+++ b/src/components/feed/post-composer.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useState } from "react";
+import { api } from "@/trpc/react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+
+const MAX_CHARS = 1000;
+
+export function PostComposer({ groupId, onPosted }: { groupId?: string; onPosted: () => void }) {
+  const [body, setBody] = useState("");
+
+  const create = api.feed.create.useMutation({
+    onSuccess: () => {
+      setBody("");
+      onPosted();
+    },
+  });
+
+  const remaining = MAX_CHARS - body.length;
+  const nearLimit = remaining <= 100;
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!body.trim()) return;
+    create.mutate({ body: body.trim(), groupId });
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2 rounded-lg border p-4">
+      <Textarea
+        placeholder="What's on your mind?"
+        rows={3}
+        value={body}
+        onChange={(e) => setBody(e.target.value)}
+        maxLength={MAX_CHARS}
+      />
+      <div className="flex items-center justify-between">
+        <span className={`text-xs ${nearLimit ? "text-destructive" : "text-muted-foreground"}`}>
+          {remaining} chars remaining
+        </span>
+        <Button type="submit" size="sm" disabled={!body.trim() || create.isPending}>
+          {create.isPending ? "Posting…" : "Post"}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/nav/notification-bell.tsx
+++ b/src/components/nav/notification-bell.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import Link from "next/link";
+import { api } from "@/trpc/react";
+
+export function NotificationBell() {
+  const { data } = api.notifications.unreadCount.useQuery(undefined, {
+    refetchInterval: 30_000, // poll every 30s
+  });
+
+  const count = data?.count ?? 0;
+
+  return (
+    <Link href="/notifications" className="relative flex items-center text-muted-foreground hover:text-foreground">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="20"
+        height="20"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />
+        <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" />
+      </svg>
+      {count > 0 && (
+        <span className="absolute -right-1.5 -top-1.5 flex h-4 w-4 items-center justify-center rounded-full bg-destructive text-[10px] font-bold text-destructive-foreground">
+          {count > 9 ? "9+" : count}
+        </span>
+      )}
+    </Link>
+  );
+}

--- a/src/components/nav/user-menu.tsx
+++ b/src/components/nav/user-menu.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { authClient } from "@/lib/auth-client";
+import { Button } from "@/components/ui/button";
+
+export function UserMenu({ name }: { name: string }) {
+  const router = useRouter();
+
+  async function handleSignOut() {
+    await authClient.signOut();
+    router.push("/login");
+    router.refresh();
+  }
+
+  return (
+    <div className="flex items-center gap-3">
+      <Link href="/settings" className="text-sm text-muted-foreground hover:text-foreground">
+        {name}
+      </Link>
+      <Button variant="outline" size="sm" onClick={handleSignOut}>
+        Sign out
+      </Button>
+    </div>
+  );
+}

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -1,0 +1,50 @@
+"use client"
+
+import * as React from "react"
+import * as AvatarPrimitive from "@radix-ui/react-avatar"
+
+import { cn } from "@/lib/utils"
+
+const Avatar = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full",
+      className
+    )}
+    {...props}
+  />
+))
+Avatar.displayName = AvatarPrimitive.Root.displayName
+
+const AvatarImage = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Image>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Image
+    ref={ref}
+    className={cn("aspect-square h-full w-full", className)}
+    {...props}
+  />
+))
+AvatarImage.displayName = AvatarPrimitive.Image.displayName
+
+const AvatarFallback = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Fallback>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Fallback>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Fallback
+    ref={ref}
+    className={cn(
+      "flex h-full w-full items-center justify-center rounded-full bg-muted",
+      className
+    )}
+    {...props}
+  />
+))
+AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName
+
+export { Avatar, AvatarImage, AvatarFallback }

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,36 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,79 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-lg border bg-card text-card-foreground shadow-sm",
+      className
+    )}
+    {...props}
+  />
+))
+Card.displayName = "Card"
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+))
+CardHeader.displayName = "CardHeader"
+
+const CardTitle = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "text-2xl font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+CardTitle.displayName = "CardTitle"
+
+const CardDescription = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+CardDescription.displayName = "CardDescription"
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+))
+CardContent.displayName = "CardContent"
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+))
+CardFooter.displayName = "CardFooter"
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,122 @@
+"use client"
+
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Dialog = DialogPrimitive.Root
+
+const DialogTrigger = DialogPrimitive.Trigger
+
+const DialogPortal = DialogPrimitive.Portal
+
+const DialogClose = DialogPrimitive.Close
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+  />
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+))
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-1.5 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+DialogHeader.displayName = "DialogHeader"
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+DialogFooter.displayName = "DialogFooter"
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+DialogTitle.displayName = DialogPrimitive.Title.displayName
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+DialogDescription.displayName = DialogPrimitive.Description.displayName
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogClose,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+}

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -1,0 +1,178 @@
+"use client"
+
+import * as React from "react"
+import * as LabelPrimitive from "@radix-ui/react-label"
+import { Slot } from "@radix-ui/react-slot"
+import {
+  Controller,
+  FormProvider,
+  useFormContext,
+  type ControllerProps,
+  type FieldPath,
+  type FieldValues,
+} from "react-hook-form"
+
+import { cn } from "@/lib/utils"
+import { Label } from "@/components/ui/label"
+
+const Form = FormProvider
+
+type FormFieldContextValue<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+> = {
+  name: TName
+}
+
+const FormFieldContext = React.createContext<FormFieldContextValue | null>(null)
+
+const FormField = <
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+>({
+  ...props
+}: ControllerProps<TFieldValues, TName>) => {
+  return (
+    <FormFieldContext.Provider value={{ name: props.name }}>
+      <Controller {...props} />
+    </FormFieldContext.Provider>
+  )
+}
+
+const useFormField = () => {
+  const fieldContext = React.useContext(FormFieldContext)
+  const itemContext = React.useContext(FormItemContext)
+  const { getFieldState, formState } = useFormContext()
+
+  if (!fieldContext) {
+    throw new Error("useFormField should be used within <FormField>")
+  }
+
+  if (!itemContext) {
+    throw new Error("useFormField should be used within <FormItem>")
+  }
+
+  const fieldState = getFieldState(fieldContext.name, formState)
+
+  const { id } = itemContext
+
+  return {
+    id,
+    name: fieldContext.name,
+    formItemId: `${id}-form-item`,
+    formDescriptionId: `${id}-form-item-description`,
+    formMessageId: `${id}-form-item-message`,
+    ...fieldState,
+  }
+}
+
+type FormItemContextValue = {
+  id: string
+}
+
+const FormItemContext = React.createContext<FormItemContextValue | null>(null)
+
+const FormItem = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+  const id = React.useId()
+
+  return (
+    <FormItemContext.Provider value={{ id }}>
+      <div ref={ref} className={cn("space-y-2", className)} {...props} />
+    </FormItemContext.Provider>
+  )
+})
+FormItem.displayName = "FormItem"
+
+const FormLabel = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
+>(({ className, ...props }, ref) => {
+  const { error, formItemId } = useFormField()
+
+  return (
+    <Label
+      ref={ref}
+      className={cn(error && "text-destructive", className)}
+      htmlFor={formItemId}
+      {...props}
+    />
+  )
+})
+FormLabel.displayName = "FormLabel"
+
+const FormControl = React.forwardRef<
+  React.ElementRef<typeof Slot>,
+  React.ComponentPropsWithoutRef<typeof Slot>
+>(({ ...props }, ref) => {
+  const { error, formItemId, formDescriptionId, formMessageId } = useFormField()
+
+  return (
+    <Slot
+      ref={ref}
+      id={formItemId}
+      aria-describedby={
+        !error
+          ? `${formDescriptionId}`
+          : `${formDescriptionId} ${formMessageId}`
+      }
+      aria-invalid={!!error}
+      {...props}
+    />
+  )
+})
+FormControl.displayName = "FormControl"
+
+const FormDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => {
+  const { formDescriptionId } = useFormField()
+
+  return (
+    <p
+      ref={ref}
+      id={formDescriptionId}
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+})
+FormDescription.displayName = "FormDescription"
+
+const FormMessage = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, children, ...props }, ref) => {
+  const { error, formMessageId } = useFormField()
+  const body = error ? String(error?.message ?? "") : children
+
+  if (!body) {
+    return null
+  }
+
+  return (
+    <p
+      ref={ref}
+      id={formMessageId}
+      className={cn("text-sm font-medium text-destructive", className)}
+      {...props}
+    >
+      {body}
+    </p>
+  )
+})
+FormMessage.displayName = "FormMessage"
+
+export {
+  useFormField,
+  Form,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormDescription,
+  FormMessage,
+  FormField,
+}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,22 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = "Input"
+
+export { Input }

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+import * as React from "react"
+import * as LabelPrimitive from "@radix-ui/react-label"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const labelVariants = cva(
+  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+)
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
+    VariantProps<typeof labelVariants>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn(labelVariants(), className)}
+    {...props}
+  />
+))
+Label.displayName = LabelPrimitive.Root.displayName
+
+export { Label }

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,22 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Textarea = React.forwardRef<
+  HTMLTextAreaElement,
+  React.ComponentProps<"textarea">
+>(({ className, ...props }, ref) => {
+  return (
+    <textarea
+      className={cn(
+        "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  )
+})
+Textarea.displayName = "Textarea"
+
+export { Textarea }

--- a/src/server/db/schema/auth.ts
+++ b/src/server/db/schema/auth.ts
@@ -14,9 +14,23 @@ export const profileVisibilityEnum = pgEnum("profile_visibility", [
 ]);
 
 export type NotificationPrefs = {
-  friendRequestReceived?: boolean;
-  friendRequestAccepted?: boolean;
-  groupInviteReceived?: boolean;
+  // ── In-app (bell) ───────────────────────────────────────────
+  friendRequestReceived?: boolean;  // default on
+  friendRequestAccepted?: boolean;  // default on
+  groupInviteReceived?: boolean;    // default on
+
+  // ── Email ────────────────────────────────────────────────────
+  // Friends
+  emailFriendRequest?: boolean;     // default off
+  // Events
+  emailEventConfirmed?: boolean;    // default on
+  emailEventCancelled?: boolean;    // default on
+  emailEventRsvpReminder?: boolean; // default on
+  // Polls
+  emailPollOpened?: boolean;        // default on
+  emailPollClosed?: boolean;        // default off
+  // Groups
+  emailGroupInvite?: boolean;       // default on
 };
 
 // better-auth user table extended with our profile fields.

--- a/src/server/db/schema/availability.ts
+++ b/src/server/db/schema/availability.ts
@@ -1,0 +1,22 @@
+import { pgEnum, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+import { user } from "./auth";
+import { groups } from "./groups";
+
+export const availabilityVisibilityEnum = pgEnum("availability_visibility", [
+  "friends",
+  "group",
+  "private",
+]);
+
+export const availabilityBlocks = pgTable("availability_blocks", {
+  id: text("id").primaryKey(),
+  userId: text("user_id")
+    .notNull()
+    .references(() => user.id, { onDelete: "cascade" }),
+  groupId: text("group_id").references(() => groups.id, { onDelete: "cascade" }),
+  startsAt: timestamp("starts_at").notNull(),
+  endsAt: timestamp("ends_at").notNull(),
+  label: text("label"),
+  visibility: availabilityVisibilityEnum("visibility").notNull().default("friends"),
+  createdAt: timestamp("created_at").notNull().defaultNow(),
+});

--- a/src/server/db/schema/events.ts
+++ b/src/server/db/schema/events.ts
@@ -1,0 +1,117 @@
+import {
+  integer,
+  pgEnum,
+  pgTable,
+  primaryKey,
+  text,
+  timestamp,
+} from "drizzle-orm/pg-core";
+import { user } from "./auth";
+import { groups } from "./groups";
+import { games } from "./games";
+
+export const eventStatusEnum = pgEnum("event_status", [
+  "draft",
+  "open",
+  "confirmed",
+  "cancelled",
+]);
+
+export const rsvpStatusEnum = pgEnum("rsvp_status", ["yes", "no", "maybe"]);
+
+export const pollTypeEnum = pgEnum("poll_type", [
+  "time_slot",
+  "game",
+  "duration",
+  "custom",
+]);
+
+export const pollStatusEnum = pgEnum("poll_status", ["open", "closed"]);
+
+// ── Event ─────────────────────────────────────────────────────────────────────
+
+export const events = pgTable("events", {
+  id: text("id").primaryKey(),
+  groupId: text("group_id")
+    .notNull()
+    .references(() => groups.id, { onDelete: "cascade" }),
+  title: text("title").notNull(),
+  description: text("description"),
+  createdBy: text("created_by")
+    .notNull()
+    .references(() => user.id),
+  status: eventStatusEnum("status").notNull().default("draft"),
+  confirmedStartsAt: timestamp("confirmed_starts_at"),
+  confirmedEndsAt: timestamp("confirmed_ends_at"),
+  createdAt: timestamp("created_at").notNull().defaultNow(),
+  updatedAt: timestamp("updated_at").notNull().defaultNow(),
+});
+
+// ── RSVP ──────────────────────────────────────────────────────────────────────
+
+export const eventRsvps = pgTable(
+  "event_rsvps",
+  {
+    eventId: text("event_id")
+      .notNull()
+      .references(() => events.id, { onDelete: "cascade" }),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    status: rsvpStatusEnum("status").notNull(),
+    note: text("note"),
+    updatedAt: timestamp("updated_at").notNull().defaultNow(),
+  },
+  (t) => ({
+    pk: primaryKey({ columns: [t.eventId, t.userId] }),
+  })
+);
+
+// ── Poll ──────────────────────────────────────────────────────────────────────
+
+export const polls = pgTable("polls", {
+  id: text("id").primaryKey(),
+  eventId: text("event_id").references(() => events.id, { onDelete: "cascade" }),
+  groupId: text("group_id").references(() => groups.id, { onDelete: "cascade" }),
+  type: pollTypeEnum("type").notNull(),
+  question: text("question").notNull(),
+  allowMultipleVotes: text("allow_multiple_votes").notNull().default("false"),
+  closesAt: timestamp("closes_at"),
+  status: pollStatusEnum("status").notNull().default("open"),
+  createdBy: text("created_by")
+    .notNull()
+    .references(() => user.id),
+  createdAt: timestamp("created_at").notNull().defaultNow(),
+});
+
+// ── Poll option ───────────────────────────────────────────────────────────────
+
+export const pollOptions = pgTable("poll_options", {
+  id: text("id").primaryKey(),
+  pollId: text("poll_id")
+    .notNull()
+    .references(() => polls.id, { onDelete: "cascade" }),
+  label: text("label").notNull(),
+  gameId: text("game_id").references(() => games.id, { onDelete: "set null" }),
+  startsAt: timestamp("starts_at"), // for time_slot polls
+  endsAt: timestamp("ends_at"),     // for time_slot polls
+  sortOrder: integer("sort_order").notNull().default(0),
+});
+
+// ── Poll vote ─────────────────────────────────────────────────────────────────
+
+export const pollVotes = pgTable(
+  "poll_votes",
+  {
+    pollOptionId: text("poll_option_id")
+      .notNull()
+      .references(() => pollOptions.id, { onDelete: "cascade" }),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+  },
+  (t) => ({
+    pk: primaryKey({ columns: [t.pollOptionId, t.userId] }),
+  })
+);

--- a/src/server/db/schema/games.ts
+++ b/src/server/db/schema/games.ts
@@ -1,0 +1,55 @@
+import {
+  integer,
+  jsonb,
+  pgEnum,
+  pgTable,
+  primaryKey,
+  text,
+  timestamp,
+} from "drizzle-orm/pg-core";
+import { user } from "./auth";
+
+export const gameSourceEnum = pgEnum("game_source", ["manual", "igdb", "steam_app"]);
+
+export const gamePlatformEnum = pgEnum("game_platform", [
+  "pc",
+  "playstation",
+  "xbox",
+  "nintendo",
+  "other",
+]);
+
+export const ownershipSourceEnum = pgEnum("ownership_source", ["manual", "steam"]);
+
+export const games = pgTable("games", {
+  id: text("id").primaryKey(),
+  title: text("title").notNull(),
+  coverUrl: text("cover_url"),
+  description: text("description"),
+  minPlayers: integer("min_players"),
+  maxPlayers: integer("max_players"),
+  genres: text("genres").array().notNull().default([]),
+  externalSource: gameSourceEnum("external_source").notNull().default("manual"),
+  externalId: text("external_id"),
+  steamAppId: text("steam_app_id"),
+  metadataJson: jsonb("metadata_json"),
+  createdAt: timestamp("created_at").notNull().defaultNow(),
+  updatedAt: timestamp("updated_at").notNull().defaultNow(),
+});
+
+export const gameOwnerships = pgTable(
+  "game_ownerships",
+  {
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    gameId: text("game_id")
+      .notNull()
+      .references(() => games.id, { onDelete: "cascade" }),
+    platform: gamePlatformEnum("platform").notNull(),
+    source: ownershipSourceEnum("source").notNull().default("manual"),
+  },
+  (t) => ({
+    pk: primaryKey({ columns: [t.userId, t.gameId, t.platform] }),
+  })
+);

--- a/src/server/db/schema/index.ts
+++ b/src/server/db/schema/index.ts
@@ -2,3 +2,7 @@ export * from "./auth";
 export * from "./friendships";
 export * from "./groups";
 export * from "./posts";
+export * from "./games";
+export * from "./availability";
+export * from "./events";
+export * from "./relations";

--- a/src/server/db/schema/relations.ts
+++ b/src/server/db/schema/relations.ts
@@ -1,0 +1,117 @@
+import { relations } from "drizzle-orm";
+import { user } from "./auth";
+import { friendships } from "./friendships";
+import { groups, groupMemberships } from "./groups";
+import { posts, comments, reactions } from "./posts";
+import { games, gameOwnerships } from "./games";
+import { availabilityBlocks } from "./availability";
+import { events, eventRsvps, polls, pollOptions, pollVotes } from "./events";
+
+export const friendshipsRelations = relations(friendships, ({ one }) => ({
+  requester: one(user, {
+    fields: [friendships.requesterId],
+    references: [user.id],
+    relationName: "requester",
+  }),
+  addressee: one(user, {
+    fields: [friendships.addresseeId],
+    references: [user.id],
+    relationName: "addressee",
+  }),
+}));
+
+export const userRelations = relations(user, ({ many }) => ({
+  sentRequests: many(friendships, { relationName: "requester" }),
+  receivedRequests: many(friendships, { relationName: "addressee" }),
+  groupMemberships: many(groupMemberships),
+}));
+
+export const groupsRelations = relations(groups, ({ many }) => ({
+  memberships: many(groupMemberships),
+}));
+
+export const groupMembershipsRelations = relations(groupMemberships, ({ one }) => ({
+  group: one(groups, {
+    fields: [groupMemberships.groupId],
+    references: [groups.id],
+  }),
+  user: one(user, {
+    fields: [groupMemberships.userId],
+    references: [user.id],
+  }),
+}));
+
+export const postsRelations = relations(posts, ({ one, many }) => ({
+  author: one(user, { fields: [posts.authorId], references: [user.id] }),
+  group: one(groups, { fields: [posts.groupId], references: [groups.id] }),
+  comments: many(comments),
+  reactions: many(reactions),
+  repostOf: one(posts, {
+    fields: [posts.repostOfId],
+    references: [posts.id],
+    relationName: "reposts",
+  }),
+}));
+
+export const commentsRelations = relations(comments, ({ one, many }) => ({
+  post: one(posts, { fields: [comments.postId], references: [posts.id] }),
+  author: one(user, { fields: [comments.authorId], references: [user.id] }),
+  reactions: many(reactions),
+}));
+
+export const reactionsRelations = relations(reactions, ({ one }) => ({
+  user: one(user, { fields: [reactions.userId], references: [user.id] }),
+  post: one(posts, { fields: [reactions.postId], references: [posts.id] }),
+  comment: one(comments, { fields: [reactions.commentId], references: [comments.id] }),
+}));
+
+// ── Games ─────────────────────────────────────────────────────────────────────
+
+export const gamesRelations = relations(games, ({ many }) => ({
+  ownerships: many(gameOwnerships),
+  pollOptions: many(pollOptions),
+}));
+
+export const gameOwnershipsRelations = relations(gameOwnerships, ({ one }) => ({
+  user: one(user, { fields: [gameOwnerships.userId], references: [user.id] }),
+  game: one(games, { fields: [gameOwnerships.gameId], references: [games.id] }),
+}));
+
+// ── Availability ──────────────────────────────────────────────────────────────
+
+export const availabilityBlocksRelations = relations(availabilityBlocks, ({ one }) => ({
+  user: one(user, { fields: [availabilityBlocks.userId], references: [user.id] }),
+  group: one(groups, { fields: [availabilityBlocks.groupId], references: [groups.id] }),
+}));
+
+// ── Events ────────────────────────────────────────────────────────────────────
+
+export const eventsRelations = relations(events, ({ one, many }) => ({
+  group: one(groups, { fields: [events.groupId], references: [groups.id] }),
+  createdBy: one(user, { fields: [events.createdBy], references: [user.id] }),
+  rsvps: many(eventRsvps),
+  polls: many(polls),
+}));
+
+export const eventRsvpsRelations = relations(eventRsvps, ({ one }) => ({
+  event: one(events, { fields: [eventRsvps.eventId], references: [events.id] }),
+  user: one(user, { fields: [eventRsvps.userId], references: [user.id] }),
+}));
+
+export const pollsRelations = relations(polls, ({ one, many }) => ({
+  event: one(events, { fields: [polls.eventId], references: [events.id] }),
+  group: one(groups, { fields: [polls.groupId], references: [groups.id] }),
+  createdBy: one(user, { fields: [polls.createdBy], references: [user.id] }),
+  options: many(pollOptions),
+}));
+
+export const pollOptionsRelations = relations(pollOptions, ({ one, many }) => ({
+  poll: one(polls, { fields: [pollOptions.pollId], references: [polls.id] }),
+  game: one(games, { fields: [pollOptions.gameId], references: [games.id] }),
+  votes: many(pollVotes),
+}));
+
+export const pollVotesRelations = relations(pollVotes, ({ one }) => ({
+  option: one(pollOptions, { fields: [pollVotes.pollOptionId], references: [pollOptions.id] }),
+  user: one(user, { fields: [pollVotes.userId], references: [user.id] }),
+}));

--- a/src/server/db/seed.ts
+++ b/src/server/db/seed.ts
@@ -1,10 +1,168 @@
+/**
+ * Seed script for local development.
+ * Creates test accounts, friendships, and a group.
+ *
+ * Run: pnpm db:seed
+ *
+ * Safe to re-run — skips rows that already exist.
+ */
+
+import { config } from "dotenv";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { hashPassword } from "better-auth/crypto";
+import * as schema from "./schema";
+
+config({ path: ".env" });
+
+const { user, account, friendships, groups, groupMemberships } = schema;
+
+const db = drizzle(postgres(process.env.DATABASE_URL!), { schema });
+
+// ── Seed data ─────────────────────────────────────────────────────────────────
+
+const SEED_USERS = [
+  {
+    id: "seed-user-alice",
+    name: "Alice",
+    username: "alice",
+    email: "alice@campfire.local",
+    password: "password123",
+    bio: "Loves RPGs and strategy games.",
+  },
+  {
+    id: "seed-user-bob",
+    name: "Bob",
+    username: "bob",
+    email: "bob@campfire.local",
+    password: "password123",
+    bio: "FPS enthusiast. Mostly plays late nights.",
+  },
+  {
+    id: "seed-user-carol",
+    name: "Carol",
+    username: "carol",
+    email: "carol@campfire.local",
+    password: "password123",
+    bio: "Indie games and couch co-op.",
+  },
+];
+
+const SEED_GROUP = {
+  id: "seed-group-main",
+  name: "Friday Night Squad",
+  description: "The usual crew for Friday sessions.",
+  inviteToken: "seed-invite-friday",
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function log(msg: string) {
+  console.log(`  ${msg}`);
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
 async function main() {
-  console.log("Seeding database...");
-  // TODO: implement seed data for local development
-  // - users, friend connections, groups, posts, notifications
-  console.log("Done.");
+  console.log("\nSeeding database...\n");
+
+  // Users + password accounts
+  for (const u of SEED_USERS) {
+    const existing = await db.query.user.findFirst({
+      where: (t, { eq }) => eq(t.id, u.id),
+      columns: { id: true },
+    });
+
+    if (existing) {
+      log(`skip  user ${u.email} (already exists)`);
+      continue;
+    }
+
+    const now = new Date();
+    await db.insert(user).values({
+      id: u.id,
+      name: u.name,
+      username: u.username,
+      email: u.email,
+      emailVerified: true,
+      bio: u.bio,
+      profileVisibility: "open",
+      notificationPrefs: {},
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const hashed = await hashPassword(u.password);
+    await db.insert(account).values({
+      id: `seed-account-${u.username}`,
+      accountId: u.id,
+      providerId: "credential",
+      userId: u.id,
+      password: hashed,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    log(`create user ${u.email}`);
+  }
+
+  // Friendships: alice ↔ bob (accepted), alice ↔ carol (accepted)
+  const friendPairs: [string, string][] = [
+    ["seed-user-alice", "seed-user-bob"],
+    ["seed-user-alice", "seed-user-carol"],
+  ];
+
+  for (const [reqId, addId] of friendPairs) {
+    const existing = await db.query.friendships.findFirst({
+      where: (t, { eq, and }) =>
+        and(eq(t.requesterId, reqId), eq(t.addresseeId, addId)),
+      columns: { requesterId: true },
+    });
+    if (existing) {
+      log(`skip  friendship ${reqId} ↔ ${addId}`);
+      continue;
+    }
+    await db.insert(friendships).values({
+      requesterId: reqId,
+      addresseeId: addId,
+      status: "accepted",
+    });
+    log(`create friendship ${reqId} ↔ ${addId}`);
+  }
+
+  // Group
+  const existingGroup = await db.query.groups.findFirst({
+    where: (t, { eq }) => eq(t.id, SEED_GROUP.id),
+    columns: { id: true },
+  });
+
+  if (!existingGroup) {
+    await db.insert(groups).values(SEED_GROUP);
+    log(`create group "${SEED_GROUP.name}"`);
+
+    // Add all three users to the group
+    const memberships = SEED_USERS.map((u, i) => ({
+      groupId: SEED_GROUP.id,
+      userId: u.id,
+      role: (i === 0 ? "owner" : "member") as "owner" | "member",
+    }));
+    await db.insert(groupMemberships).values(memberships);
+    log(`create group memberships (alice=owner, bob+carol=member)`);
+  } else {
+    log(`skip  group "${SEED_GROUP.name}" (already exists)`);
+  }
+
+  console.log("\nDone.\n");
+  console.log("Test accounts (password: password123):");
+  for (const u of SEED_USERS) {
+    console.log(`  ${u.email}  @${u.username}`);
+  }
+  console.log();
 }
 
 main()
-  .catch(console.error)
-  .finally(() => process.exit());
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  })
+  .finally(() => process.exit(0));

--- a/src/server/email.ts
+++ b/src/server/email.ts
@@ -1,0 +1,31 @@
+import nodemailer from "nodemailer";
+import { env } from "@/env";
+
+// Singleton transport — reused across all email sends in the worker process.
+export const transport = nodemailer.createTransport({
+  host: env.SMTP_HOST,
+  port: env.SMTP_PORT,
+  // Port 465 = implicit TLS, everything else = STARTTLS (or plain for Mailhog)
+  secure: env.SMTP_PORT === 465,
+  auth:
+    env.SMTP_USER && env.SMTP_PASS
+      ? { user: env.SMTP_USER, pass: env.SMTP_PASS }
+      : undefined,
+});
+
+export type SendEmailOptions = {
+  to: string;
+  subject: string;
+  html: string;
+  text: string;
+};
+
+export async function sendEmail({ to, subject, html, text }: SendEmailOptions) {
+  await transport.sendMail({
+    from: env.EMAIL_FROM,
+    to,
+    subject,
+    html,
+    text,
+  });
+}

--- a/src/server/jobs/email-jobs.ts
+++ b/src/server/jobs/email-jobs.ts
@@ -1,0 +1,117 @@
+import { Queue } from "bullmq";
+import { bullmqConnection } from "@/server/redis";
+
+// ── Job payload types ─────────────────────────────────────────────────────────
+
+export type EmailJobType =
+  | "event_confirmed"
+  | "event_cancelled"
+  | "event_rsvp_reminder"
+  | "poll_opened"
+  | "poll_closed"
+  | "group_invite"
+  | "friend_request";
+
+export type EventConfirmedPayload = {
+  type: "event_confirmed";
+  eventId: string;
+  eventTitle: string;
+  groupName: string;
+  confirmedStartsAt: string; // ISO string
+  confirmedEndsAt: string | null;
+  recipientUserIds: string[]; // users who RSVPd yes/maybe
+};
+
+export type EventCancelledPayload = {
+  type: "event_cancelled";
+  eventId: string;
+  eventTitle: string;
+  groupName: string;
+  recipientUserIds: string[];
+};
+
+export type EventRsvpReminderPayload = {
+  type: "event_rsvp_reminder";
+  eventId: string;
+  eventTitle: string;
+  groupName: string;
+  recipientUserIds: string[]; // members who haven't RSVPd
+};
+
+export type PollOpenedPayload = {
+  type: "poll_opened";
+  pollId: string;
+  pollQuestion: string;
+  groupName: string;
+  eventTitle?: string;
+  recipientUserIds: string[];
+};
+
+export type PollClosedPayload = {
+  type: "poll_closed";
+  pollId: string;
+  pollQuestion: string;
+  groupName: string;
+  recipientUserIds: string[]; // users who voted
+};
+
+export type GroupInvitePayload = {
+  type: "group_invite";
+  groupId: string;
+  groupName: string;
+  inviterName: string;
+  recipientUserId: string;
+};
+
+export type FriendRequestPayload = {
+  type: "friend_request";
+  requesterName: string;
+  recipientUserId: string;
+};
+
+export type EmailJobPayload =
+  | EventConfirmedPayload
+  | EventCancelledPayload
+  | EventRsvpReminderPayload
+  | PollOpenedPayload
+  | PollClosedPayload
+  | GroupInvitePayload
+  | FriendRequestPayload;
+
+// ── Queue (shared singleton) ──────────────────────────────────────────────────
+
+export const emailQueue = new Queue<EmailJobPayload>("email", {
+  connection: bullmqConnection,
+  defaultJobOptions: {
+    attempts: 3,
+    backoff: { type: "exponential", delay: 5000 },
+    removeOnComplete: 100,
+    removeOnFail: 200,
+  },
+});
+
+// ── Enqueue helpers ───────────────────────────────────────────────────────────
+
+export function enqueueEventConfirmed(payload: Omit<EventConfirmedPayload, "type">) {
+  return emailQueue.add("event_confirmed", { type: "event_confirmed", ...payload });
+}
+
+export function enqueueEventCancelled(payload: Omit<EventCancelledPayload, "type">) {
+  return emailQueue.add("event_cancelled", { type: "event_cancelled", ...payload });
+}
+
+export function enqueueEventRsvpReminder(payload: Omit<EventRsvpReminderPayload, "type">, delay?: number) {
+  return emailQueue.add(
+    "event_rsvp_reminder",
+    { type: "event_rsvp_reminder", ...payload },
+    delay ? { delay } : undefined
+  );
+}
+
+export function enqueuePollOpened(payload: Omit<PollOpenedPayload, "type">) {
+  return emailQueue.add("poll_opened", { type: "poll_opened", ...payload });
+}
+
+export function enqueuePollClosed(payload: Omit<PollClosedPayload, "type">) {
+  return emailQueue.add("poll_closed", { type: "poll_closed", ...payload });
+}

--- a/src/server/trpc/routers/_app.ts
+++ b/src/server/trpc/routers/_app.ts
@@ -1,8 +1,24 @@
 import { createTRPCRouter } from "@/server/trpc/trpc";
 import { userRouter } from "./user";
+import { friendsRouter } from "./friends";
+import { groupsRouter } from "./groups";
+import { feedRouter } from "./feed";
+import { notificationsRouter } from "./notifications";
+import { gamesRouter } from "./games";
+import { availabilityRouter } from "./availability";
+import { eventsRouter } from "./events";
+import { pollsRouter } from "./polls";
 
 export const appRouter = createTRPCRouter({
   user: userRouter,
+  friends: friendsRouter,
+  groups: groupsRouter,
+  feed: feedRouter,
+  notifications: notificationsRouter,
+  games: gamesRouter,
+  availability: availabilityRouter,
+  events: eventsRouter,
+  polls: pollsRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/src/server/trpc/routers/availability.ts
+++ b/src/server/trpc/routers/availability.ts
@@ -1,0 +1,151 @@
+import { z } from "zod";
+import { and, eq, gte, lte, or } from "drizzle-orm";
+import { TRPCError } from "@trpc/server";
+import { createId } from "@paralleldrive/cuid2";
+import { createTRPCRouter, protectedProcedure } from "@/server/trpc/trpc";
+import { db } from "@/server/db";
+import { availabilityBlocks } from "@/server/db/schema";
+
+const VISIBILITIES = ["friends", "group", "private"] as const;
+
+const blockInput = z.object({
+  startsAt: z.string().datetime(),
+  endsAt: z.string().datetime(),
+  label: z.string().max(100).optional(),
+  visibility: z.enum(VISIBILITIES).default("friends"),
+  groupId: z.string().optional(),
+});
+
+export const availabilityRouter = createTRPCRouter({
+  // Create a new availability block (CAMP-050)
+  create: protectedProcedure.input(blockInput).mutation(async ({ ctx, input }) => {
+    const startsAt = new Date(input.startsAt);
+    const endsAt = new Date(input.endsAt);
+    if (endsAt <= startsAt) {
+      throw new TRPCError({ code: "BAD_REQUEST", message: "End time must be after start time" });
+    }
+    const id = createId();
+    await db.insert(availabilityBlocks).values({
+      id,
+      userId: ctx.user.id,
+      startsAt,
+      endsAt,
+      label: input.label ?? null,
+      visibility: input.visibility,
+      groupId: input.groupId ?? null,
+    });
+    return { id };
+  }),
+
+  // Update an existing block (CAMP-051)
+  update: protectedProcedure
+    .input(z.object({ id: z.string() }).merge(blockInput.partial()))
+    .mutation(async ({ ctx, input }) => {
+      const block = await db.query.availabilityBlocks.findFirst({
+        where: eq(availabilityBlocks.id, input.id),
+      });
+      if (!block) throw new TRPCError({ code: "NOT_FOUND" });
+      if (block.userId !== ctx.user.id) throw new TRPCError({ code: "FORBIDDEN" });
+
+      const startsAt = input.startsAt ? new Date(input.startsAt) : block.startsAt;
+      const endsAt = input.endsAt ? new Date(input.endsAt) : block.endsAt;
+      if (endsAt <= startsAt) {
+        throw new TRPCError({ code: "BAD_REQUEST", message: "End time must be after start time" });
+      }
+
+      await db
+        .update(availabilityBlocks)
+        .set({
+          startsAt,
+          endsAt,
+          label: input.label !== undefined ? (input.label ?? null) : block.label,
+          visibility: input.visibility ?? block.visibility,
+          groupId: input.groupId !== undefined ? (input.groupId ?? null) : block.groupId,
+        })
+        .where(eq(availabilityBlocks.id, input.id));
+
+      return { id: input.id };
+    }),
+
+  // Delete a block (CAMP-052)
+  delete: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const block = await db.query.availabilityBlocks.findFirst({
+        where: eq(availabilityBlocks.id, input.id),
+      });
+      if (!block) throw new TRPCError({ code: "NOT_FOUND" });
+      if (block.userId !== ctx.user.id) throw new TRPCError({ code: "FORBIDDEN" });
+      await db.delete(availabilityBlocks).where(eq(availabilityBlocks.id, input.id));
+      return { id: input.id };
+    }),
+
+  // My availability blocks within a date range
+  myBlocks: protectedProcedure
+    .input(
+      z.object({
+        from: z.string().datetime(),
+        to: z.string().datetime(),
+      })
+    )
+    .query(async ({ ctx, input }) => {
+      return db.query.availabilityBlocks.findMany({
+        where: and(
+          eq(availabilityBlocks.userId, ctx.user.id),
+          gte(availabilityBlocks.startsAt, new Date(input.from)),
+          lte(availabilityBlocks.endsAt, new Date(input.to))
+        ),
+        orderBy: (t, { asc }) => [asc(t.startsAt)],
+      });
+    }),
+
+  // All blocks visible to me within a group (CAMP-053)
+  groupOverlap: protectedProcedure
+    .input(
+      z.object({
+        groupId: z.string(),
+        from: z.string().datetime(),
+        to: z.string().datetime(),
+      })
+    )
+    .query(async ({ ctx, input }) => {
+      const { groupMemberships } = await import("@/server/db/schema");
+
+      // Verify caller is a member
+      const membership = await db.query.groupMemberships.findFirst({
+        where: and(
+          eq(groupMemberships.groupId, input.groupId),
+          eq(groupMemberships.userId, ctx.user.id)
+        ),
+      });
+      if (!membership) throw new TRPCError({ code: "FORBIDDEN" });
+
+      // Get all member IDs
+      const allMembers = await db.query.groupMemberships.findMany({
+        where: eq(groupMemberships.groupId, input.groupId),
+      });
+      const memberIds = allMembers.map((m) => m.userId);
+
+      // Get blocks for all members that are visible (group or friends visibility)
+      const blocks = await db.query.availabilityBlocks.findMany({
+        where: and(
+          or(...memberIds.map((id) => eq(availabilityBlocks.userId, id))),
+          gte(availabilityBlocks.startsAt, new Date(input.from)),
+          lte(availabilityBlocks.endsAt, new Date(input.to)),
+          or(
+            eq(availabilityBlocks.visibility, "friends"),
+            and(
+              eq(availabilityBlocks.visibility, "group"),
+              eq(availabilityBlocks.groupId, input.groupId)
+            )
+          )
+        ),
+        with: {
+          user: { columns: { id: true, name: true, username: true, image: true } },
+        },
+        orderBy: (t, { asc }) => [asc(t.startsAt)],
+      });
+
+      return blocks;
+    }),
+});

--- a/src/server/trpc/routers/events.ts
+++ b/src/server/trpc/routers/events.ts
@@ -1,0 +1,227 @@
+import { z } from "zod";
+import { and, eq } from "drizzle-orm";
+import { TRPCError } from "@trpc/server";
+import { createId } from "@paralleldrive/cuid2";
+import { createTRPCRouter, protectedProcedure } from "@/server/trpc/trpc";
+import { db } from "@/server/db";
+import { events, eventRsvps, groupMemberships, groups } from "@/server/db/schema";
+import {
+  enqueueEventConfirmed,
+  enqueueEventCancelled,
+  enqueueEventRsvpReminder,
+} from "@/server/jobs/email-jobs";
+
+const EVENT_STATUSES = ["draft", "open", "confirmed", "cancelled"] as const;
+
+async function assertMember(groupId: string, userId: string) {
+  const m = await db.query.groupMemberships.findFirst({
+    where: and(eq(groupMemberships.groupId, groupId), eq(groupMemberships.userId, userId)),
+  });
+  if (!m) throw new TRPCError({ code: "FORBIDDEN" });
+  return m;
+}
+
+async function assertEventMember(eventId: string, userId: string) {
+  const event = await db.query.events.findFirst({ where: eq(events.id, eventId) });
+  if (!event) throw new TRPCError({ code: "NOT_FOUND" });
+  await assertMember(event.groupId, userId);
+  return event;
+}
+
+export const eventsRouter = createTRPCRouter({
+  // Create an event within a group (CAMP-060)
+  create: protectedProcedure
+    .input(
+      z.object({
+        groupId: z.string(),
+        title: z.string().min(1).max(200),
+        description: z.string().max(2000).optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      await assertMember(input.groupId, ctx.user.id);
+      const id = createId();
+      await db.insert(events).values({
+        id,
+        groupId: input.groupId,
+        title: input.title,
+        description: input.description ?? null,
+        createdBy: ctx.user.id,
+        status: "draft",
+      });
+      return { id };
+    }),
+
+  // List events for a group
+  list: protectedProcedure
+    .input(z.object({ groupId: z.string() }))
+    .query(async ({ ctx, input }) => {
+      await assertMember(input.groupId, ctx.user.id);
+      return db.query.events.findMany({
+        where: eq(events.groupId, input.groupId),
+        with: {
+          createdBy: { columns: { id: true, name: true, username: true } },
+          rsvps: { columns: { userId: true, status: true } },
+          polls: { columns: { id: true, type: true, question: true, status: true } },
+        },
+        orderBy: (t, { desc }) => [desc(t.createdAt)],
+      });
+    }),
+
+  // Get a single event with full detail
+  get: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .query(async ({ ctx, input }) => {
+      const event = await db.query.events.findFirst({
+        where: eq(events.id, input.id),
+        with: {
+          createdBy: { columns: { id: true, name: true, username: true, image: true } },
+          rsvps: {
+            with: { user: { columns: { id: true, name: true, username: true, image: true } } },
+          },
+          polls: {
+            with: {
+              options: {
+                with: { votes: { columns: { userId: true } } },
+                orderBy: (t, { asc }) => [asc(t.sortOrder)],
+              },
+            },
+          },
+        },
+      });
+      if (!event) throw new TRPCError({ code: "NOT_FOUND" });
+      await assertMember(event.groupId, ctx.user.id);
+      return event;
+    }),
+
+  // Update event status (open → confirmed / cancelled etc.) (CAMP-061)
+  updateStatus: protectedProcedure
+    .input(
+      z.object({
+        id: z.string(),
+        status: z.enum(EVENT_STATUSES),
+        confirmedStartsAt: z.string().datetime().optional(),
+        confirmedEndsAt: z.string().datetime().optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const event = await assertEventMember(input.id, ctx.user.id);
+      if (event.createdBy !== ctx.user.id) throw new TRPCError({ code: "FORBIDDEN" });
+
+      const confirmedStartsAt = input.confirmedStartsAt
+        ? new Date(input.confirmedStartsAt)
+        : event.confirmedStartsAt;
+      const confirmedEndsAt = input.confirmedEndsAt
+        ? new Date(input.confirmedEndsAt)
+        : event.confirmedEndsAt;
+
+      await db
+        .update(events)
+        .set({
+          status: input.status,
+          confirmedStartsAt,
+          confirmedEndsAt,
+          updatedAt: new Date(),
+        })
+        .where(eq(events.id, input.id));
+
+      // Fire email jobs for relevant status transitions
+      if (input.status === "confirmed" || input.status === "cancelled") {
+        const [rsvps, group] = await Promise.all([
+          db.query.eventRsvps.findMany({
+            where: eq(eventRsvps.eventId, input.id),
+            columns: { userId: true, status: true },
+          }),
+          db.query.groups.findFirst({
+            where: eq(groups.id, event.groupId),
+            columns: { name: true },
+          }),
+        ]);
+
+        const groupName = group?.name ?? "your group";
+        const attendeeIds = rsvps
+          .filter((r) => r.status === "yes" || r.status === "maybe")
+          .map((r) => r.userId);
+
+        if (input.status === "confirmed" && confirmedStartsAt) {
+          void enqueueEventConfirmed({
+            eventId: input.id,
+            eventTitle: event.title,
+            groupName,
+            confirmedStartsAt: confirmedStartsAt.toISOString(),
+            confirmedEndsAt: confirmedEndsAt?.toISOString() ?? null,
+            recipientUserIds: attendeeIds,
+          });
+
+          // Schedule an RSVP reminder 24 h before the event for members who haven't RSVPd
+          const allMembers = await db.query.groupMemberships.findMany({
+            where: eq(groupMemberships.groupId, event.groupId),
+            columns: { userId: true },
+          });
+          const rsvpdIds = new Set(rsvps.map((r) => r.userId));
+          const unrsvpdIds = allMembers
+            .map((m) => m.userId)
+            .filter((id) => !rsvpdIds.has(id));
+
+          const msUntilEvent = confirmedStartsAt.getTime() - Date.now();
+          const reminderDelay = msUntilEvent - 24 * 60 * 60 * 1000;
+          if (reminderDelay > 0 && unrsvpdIds.length > 0) {
+            void enqueueEventRsvpReminder(
+              { eventId: input.id, eventTitle: event.title, groupName, recipientUserIds: unrsvpdIds },
+              reminderDelay
+            );
+          }
+        }
+
+        if (input.status === "cancelled") {
+          void enqueueEventCancelled({
+            eventId: input.id,
+            eventTitle: event.title,
+            groupName,
+            recipientUserIds: attendeeIds,
+          });
+        }
+      }
+
+      return { id: input.id };
+    }),
+
+  // Upsert RSVP for the current user (CAMP-068)
+  upsertRsvp: protectedProcedure
+    .input(
+      z.object({
+        eventId: z.string(),
+        status: z.enum(["yes", "no", "maybe"]),
+        note: z.string().max(500).optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const event = await assertEventMember(input.eventId, ctx.user.id);
+      if (event.status === "cancelled") {
+        throw new TRPCError({ code: "BAD_REQUEST", message: "Event is cancelled." });
+      }
+
+      const existing = await db.query.eventRsvps.findFirst({
+        where: and(
+          eq(eventRsvps.eventId, input.eventId),
+          eq(eventRsvps.userId, ctx.user.id)
+        ),
+      });
+
+      if (existing) {
+        await db
+          .update(eventRsvps)
+          .set({ status: input.status, note: input.note ?? null, updatedAt: new Date() })
+          .where(and(eq(eventRsvps.eventId, input.eventId), eq(eventRsvps.userId, ctx.user.id)));
+      } else {
+        await db.insert(eventRsvps).values({
+          eventId: input.eventId,
+          userId: ctx.user.id,
+          status: input.status,
+          note: input.note ?? null,
+        });
+      }
+
+      return { eventId: input.eventId, status: input.status };
+    }),
+});

--- a/src/server/trpc/routers/feed.ts
+++ b/src/server/trpc/routers/feed.ts
@@ -1,0 +1,169 @@
+import { z } from "zod";
+import { and, asc, desc, eq, isNull, or, inArray, ne } from "drizzle-orm";
+import { TRPCError } from "@trpc/server";
+import { createId } from "@paralleldrive/cuid2";
+import { createTRPCRouter, protectedProcedure } from "@/server/trpc/trpc";
+import { db } from "@/server/db";
+import { posts, comments, reactions, friendships, groupMemberships } from "@/server/db/schema";
+
+export const feedRouter = createTRPCRouter({
+  // Unified feed: friends + groups, block-filtered, cursor-paginated (CAMP-096)
+  list: protectedProcedure
+    .input(z.object({ cursor: z.string().optional(), limit: z.number().min(1).max(50).default(20) }))
+    .query(async ({ ctx, input }) => {
+      const me = ctx.user.id;
+
+      // Friends
+      const friendRows = await db
+        .select()
+        .from(friendships)
+        .where(
+          and(
+            or(eq(friendships.requesterId, me), eq(friendships.addresseeId, me)),
+            eq(friendships.status, "accepted")
+          )
+        );
+      const friendIds = friendRows.map((r) =>
+        r.requesterId === me ? r.addresseeId : r.requesterId
+      );
+
+      // Blocked users (both directions)
+      const blockedRows = await db
+        .select()
+        .from(friendships)
+        .where(
+          and(
+            or(eq(friendships.requesterId, me), eq(friendships.addresseeId, me)),
+            eq(friendships.status, "blocked")
+          )
+        );
+      const blockedIds = blockedRows.map((r) =>
+        r.requesterId === me ? r.addresseeId : r.requesterId
+      );
+
+      // Groups I'm in
+      const memberRows = await db
+        .select({ groupId: groupMemberships.groupId })
+        .from(groupMemberships)
+        .where(eq(groupMemberships.userId, me));
+      const myGroupIds = memberRows.map((r) => r.groupId);
+
+      // Build author filter: my own posts + friends + group posts, minus blocked
+      const visibleAuthorIds = [me, ...friendIds].filter((id) => !blockedIds.includes(id));
+
+      const feedPosts = await db.query.posts.findMany({
+        where: and(
+          isNull(posts.deletedAt),
+          or(
+            visibleAuthorIds.length > 0 ? inArray(posts.authorId, visibleAuthorIds) : undefined,
+            myGroupIds.length > 0 ? inArray(posts.groupId, myGroupIds) : undefined
+          ),
+          // Cursor
+          input.cursor ? ne(posts.id, input.cursor) : undefined
+        ),
+        orderBy: [desc(posts.createdAt)],
+        limit: input.limit + 1,
+        with: {
+          author: { columns: { id: true, name: true, username: true, image: true } },
+          group: { columns: { id: true, name: true } },
+          reactions: { columns: { id: true, userId: true, type: true } },
+          comments: {
+            where: isNull(comments.deletedAt),
+            orderBy: [asc(comments.createdAt)],
+            limit: 20,
+            with: {
+              author: { columns: { id: true, name: true, username: true, image: true } },
+              reactions: { columns: { id: true, userId: true, type: true } },
+            },
+          },
+        },
+      });
+
+      const hasMore = feedPosts.length > input.limit;
+      const items = hasMore ? feedPosts.slice(0, input.limit) : feedPosts;
+      const nextCursor = hasMore ? items[items.length - 1]?.id : undefined;
+
+      return { items, nextCursor };
+    }),
+
+  // Create a post (CAMP-080)
+  create: protectedProcedure
+    .input(
+      z.object({
+        body: z.string().min(1).max(1000),
+        groupId: z.string().optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const id = createId();
+      await db.insert(posts).values({
+        id,
+        authorId: ctx.user.id,
+        body: input.body,
+        groupId: input.groupId ?? null,
+      });
+      return { id };
+    }),
+
+  // Soft-delete own post (CAMP-087)
+  delete: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const post = await db.query.posts.findFirst({
+        where: and(eq(posts.id, input.id), eq(posts.authorId, ctx.user.id)),
+        columns: { id: true },
+      });
+      if (!post) throw new TRPCError({ code: "NOT_FOUND" });
+      await db.update(posts).set({ deletedAt: new Date() }).where(eq(posts.id, input.id));
+    }),
+
+  // Add a comment (CAMP-088)
+  comment: protectedProcedure
+    .input(z.object({ postId: z.string(), body: z.string().min(1).max(1000) }))
+    .mutation(async ({ ctx, input }) => {
+      const id = createId();
+      await db.insert(comments).values({
+        id,
+        postId: input.postId,
+        authorId: ctx.user.id,
+        body: input.body,
+      });
+      return { id };
+    }),
+
+  // Delete own comment
+  deleteComment: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const comment = await db.query.comments.findFirst({
+        where: and(eq(comments.id, input.id), eq(comments.authorId, ctx.user.id)),
+        columns: { id: true },
+      });
+      if (!comment) throw new TRPCError({ code: "NOT_FOUND" });
+      await db.update(comments).set({ deletedAt: new Date() }).where(eq(comments.id, input.id));
+    }),
+
+  // Toggle like on a post (CAMP-089)
+  toggleLike: protectedProcedure
+    .input(z.object({ postId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const existing = await db.query.reactions.findFirst({
+        where: and(
+          eq(reactions.userId, ctx.user.id),
+          eq(reactions.postId, input.postId)
+        ),
+        columns: { id: true },
+      });
+      if (existing) {
+        await db.delete(reactions).where(eq(reactions.id, existing.id));
+        return { liked: false };
+      }
+      await db.insert(reactions).values({
+        id: createId(),
+        userId: ctx.user.id,
+        postId: input.postId,
+        type: "like",
+      });
+      return { liked: true };
+    }),
+});

--- a/src/server/trpc/routers/friends.ts
+++ b/src/server/trpc/routers/friends.ts
@@ -1,0 +1,201 @@
+import { z } from "zod";
+import { and, eq, ilike, ne, or } from "drizzle-orm";
+import { TRPCError } from "@trpc/server";
+import { createId } from "@paralleldrive/cuid2";
+import { createTRPCRouter, protectedProcedure } from "@/server/trpc/trpc";
+import { db } from "@/server/db";
+import { user, friendships, notifications } from "@/server/db/schema";
+
+export const friendsRouter = createTRPCRouter({
+  // Search open-profile users by username or display name (CAMP-020)
+  search: protectedProcedure
+    .input(z.object({ query: z.string().min(1).max(50) }))
+    .query(async ({ ctx, input }) => {
+      const term = `%${input.query}%`;
+      return db
+        .select({
+          id: user.id,
+          name: user.name,
+          username: user.username,
+          image: user.image,
+        })
+        .from(user)
+        .where(
+          and(
+            ne(user.id, ctx.user.id),
+            eq(user.profileVisibility, "open"),
+            or(ilike(user.username, term), ilike(user.name, term))
+          )
+        )
+        .limit(20);
+    }),
+
+  // Send a friend request (CAMP-024)
+  sendRequest: protectedProcedure
+    .input(z.object({ addresseeId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      if (input.addresseeId === ctx.user.id) {
+        throw new TRPCError({ code: "BAD_REQUEST", message: "You cannot add yourself." });
+      }
+      // Check if a row already exists in either direction
+      const existing = await db.query.friendships.findFirst({
+        where: or(
+          and(eq(friendships.requesterId, ctx.user.id), eq(friendships.addresseeId, input.addresseeId)),
+          and(eq(friendships.requesterId, input.addresseeId), eq(friendships.addresseeId, ctx.user.id))
+        ),
+      });
+      if (existing) {
+        if (existing.status === "blocked") {
+          throw new TRPCError({ code: "FORBIDDEN", message: "Action not allowed." });
+        }
+        throw new TRPCError({ code: "CONFLICT", message: "Friend request already exists." });
+      }
+      await db.insert(friendships).values({
+        requesterId: ctx.user.id,
+        addresseeId: input.addresseeId,
+        status: "pending",
+      });
+      // Notify the addressee (CAMP-121)
+      await db.insert(notifications).values({
+        id: createId(),
+        userId: input.addresseeId,
+        type: "friend_request_received",
+        data: { requesterId: ctx.user.id, requesterName: ctx.user.name },
+      });
+    }),
+
+  // Accept or decline a pending request (CAMP-025)
+  respondToRequest: protectedProcedure
+    .input(z.object({ requesterId: z.string(), accept: z.boolean() }))
+    .mutation(async ({ ctx, input }) => {
+      const row = await db.query.friendships.findFirst({
+        where: and(
+          eq(friendships.requesterId, input.requesterId),
+          eq(friendships.addresseeId, ctx.user.id),
+          eq(friendships.status, "pending")
+        ),
+      });
+      if (!row) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Request not found." });
+      }
+      if (input.accept) {
+        await db
+          .update(friendships)
+          .set({ status: "accepted", updatedAt: new Date() })
+          .where(
+            and(
+              eq(friendships.requesterId, input.requesterId),
+              eq(friendships.addresseeId, ctx.user.id)
+            )
+          );
+        // Notify the original requester (CAMP-122)
+        await db.insert(notifications).values({
+          id: createId(),
+          userId: input.requesterId,
+          type: "friend_request_accepted",
+          data: { acceptorId: ctx.user.id, acceptorName: ctx.user.name },
+        });
+      } else {
+        await db
+          .delete(friendships)
+          .where(
+            and(
+              eq(friendships.requesterId, input.requesterId),
+              eq(friendships.addresseeId, ctx.user.id)
+            )
+          );
+      }
+    }),
+
+  // Cancel an outgoing pending request (CAMP-025)
+  cancelRequest: protectedProcedure
+    .input(z.object({ addresseeId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      await db
+        .delete(friendships)
+        .where(
+          and(
+            eq(friendships.requesterId, ctx.user.id),
+            eq(friendships.addresseeId, input.addresseeId),
+            eq(friendships.status, "pending")
+          )
+        );
+    }),
+
+  // List friends and incoming requests (CAMP-026)
+  list: protectedProcedure.query(async ({ ctx }) => {
+    const rows = await db.query.friendships.findMany({
+      where: or(
+        eq(friendships.requesterId, ctx.user.id),
+        eq(friendships.addresseeId, ctx.user.id)
+      ),
+      with: {
+        requester: { columns: { id: true, name: true, username: true, image: true } },
+        addressee: { columns: { id: true, name: true, username: true, image: true } },
+      },
+    });
+
+    const friends = rows
+      .filter((r) => r.status === "accepted")
+      .map((r) => (r.requesterId === ctx.user.id ? r.addressee : r.requester));
+
+    const incoming = rows
+      .filter((r) => r.status === "pending" && r.addresseeId === ctx.user.id)
+      .map((r) => r.requester);
+
+    const outgoing = rows
+      .filter((r) => r.status === "pending" && r.requesterId === ctx.user.id)
+      .map((r) => r.addressee);
+
+    return { friends, incoming, outgoing };
+  }),
+
+  // Remove a friend (CAMP-027)
+  remove: protectedProcedure
+    .input(z.object({ friendId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      await db
+        .delete(friendships)
+        .where(
+          or(
+            and(eq(friendships.requesterId, ctx.user.id), eq(friendships.addresseeId, input.friendId)),
+            and(eq(friendships.requesterId, input.friendId), eq(friendships.addresseeId, ctx.user.id))
+          )
+        );
+    }),
+
+  // Block a user (CAMP-028)
+  block: protectedProcedure
+    .input(z.object({ targetId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      // Delete any existing friendship row in either direction, then insert blocked
+      await db
+        .delete(friendships)
+        .where(
+          or(
+            and(eq(friendships.requesterId, ctx.user.id), eq(friendships.addresseeId, input.targetId)),
+            and(eq(friendships.requesterId, input.targetId), eq(friendships.addresseeId, ctx.user.id))
+          )
+        );
+      await db.insert(friendships).values({
+        requesterId: ctx.user.id,
+        addresseeId: input.targetId,
+        status: "blocked",
+      });
+    }),
+
+  // Unblock (CAMP-029)
+  unblock: protectedProcedure
+    .input(z.object({ targetId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      await db
+        .delete(friendships)
+        .where(
+          and(
+            eq(friendships.requesterId, ctx.user.id),
+            eq(friendships.addresseeId, input.targetId),
+            eq(friendships.status, "blocked")
+          )
+        );
+    }),
+});

--- a/src/server/trpc/routers/games.ts
+++ b/src/server/trpc/routers/games.ts
@@ -1,0 +1,151 @@
+import { z } from "zod";
+import { and, eq, ilike, or } from "drizzle-orm";
+import { TRPCError } from "@trpc/server";
+import { createId } from "@paralleldrive/cuid2";
+import { createTRPCRouter, protectedProcedure } from "@/server/trpc/trpc";
+import { db } from "@/server/db";
+import { games, gameOwnerships } from "@/server/db/schema";
+
+const PLATFORMS = ["pc", "playstation", "xbox", "nintendo", "other"] as const;
+
+export const gamesRouter = createTRPCRouter({
+  // Search the game catalog by title (CAMP-062 quick-add support)
+  search: protectedProcedure
+    .input(z.object({ query: z.string().min(1).max(100) }))
+    .query(async ({ input }) => {
+      return db
+        .select({
+          id: games.id,
+          title: games.title,
+          coverUrl: games.coverUrl,
+          minPlayers: games.minPlayers,
+          maxPlayers: games.maxPlayers,
+          genres: games.genres,
+        })
+        .from(games)
+        .where(ilike(games.title, `%${input.query}%`))
+        .limit(20);
+    }),
+
+  // Create a manual game record (CAMP-100)
+  create: protectedProcedure
+    .input(
+      z.object({
+        title: z.string().min(1).max(200),
+        description: z.string().max(1000).optional(),
+        minPlayers: z.number().int().min(1).optional(),
+        maxPlayers: z.number().int().min(1).optional(),
+        genres: z.array(z.string()).max(10).default([]),
+      })
+    )
+    .mutation(async ({ input }) => {
+      const id = createId();
+      await db.insert(games).values({
+        id,
+        title: input.title,
+        description: input.description ?? null,
+        minPlayers: input.minPlayers ?? null,
+        maxPlayers: input.maxPlayers ?? null,
+        genres: input.genres,
+        externalSource: "manual",
+      });
+      return { id };
+    }),
+
+  // Get a single game with ownership info for the current user
+  get: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .query(async ({ ctx, input }) => {
+      const game = await db.query.games.findFirst({
+        where: eq(games.id, input.id),
+        with: { ownerships: { columns: { userId: true, platform: true, source: true } } },
+      });
+      if (!game) throw new TRPCError({ code: "NOT_FOUND" });
+      const myPlatforms = game.ownerships
+        .filter((o) => o.userId === ctx.user.id)
+        .map((o) => o.platform);
+      return { ...game, myPlatforms };
+    }),
+
+  // Toggle ownership for the current user on a platform (CAMP-102/103)
+  toggleOwnership: protectedProcedure
+    .input(z.object({ gameId: z.string(), platform: z.enum(PLATFORMS) }))
+    .mutation(async ({ ctx, input }) => {
+      const existing = await db.query.gameOwnerships.findFirst({
+        where: and(
+          eq(gameOwnerships.userId, ctx.user.id),
+          eq(gameOwnerships.gameId, input.gameId),
+          eq(gameOwnerships.platform, input.platform)
+        ),
+      });
+      if (existing) {
+        await db
+          .delete(gameOwnerships)
+          .where(
+            and(
+              eq(gameOwnerships.userId, ctx.user.id),
+              eq(gameOwnerships.gameId, input.gameId),
+              eq(gameOwnerships.platform, input.platform)
+            )
+          );
+        return { owned: false };
+      }
+      await db.insert(gameOwnerships).values({
+        userId: ctx.user.id,
+        gameId: input.gameId,
+        platform: input.platform,
+        source: "manual",
+      });
+      return { owned: true };
+    }),
+
+  // My games library (CAMP-106)
+  myGames: protectedProcedure
+    .input(z.object({ platform: z.enum(PLATFORMS).optional() }))
+    .query(async ({ ctx, input }) => {
+      const rows = await db.query.gameOwnerships.findMany({
+        where: and(
+          eq(gameOwnerships.userId, ctx.user.id),
+          input.platform ? eq(gameOwnerships.platform, input.platform) : undefined
+        ),
+        with: {
+          game: {
+            columns: {
+              id: true,
+              title: true,
+              coverUrl: true,
+              genres: true,
+              minPlayers: true,
+              maxPlayers: true,
+            },
+          },
+        },
+      });
+      return rows.map((r) => ({ ...r.game, platform: r.platform, source: r.source }));
+    }),
+
+  // Ownership overlap for a game within a group (CAMP-104)
+  ownershipOverlap: protectedProcedure
+    .input(z.object({ gameId: z.string(), groupId: z.string() }))
+    .query(async ({ ctx, input }) => {
+      // Get all members of the group
+      const { groupMemberships } = await import("@/server/db/schema");
+      const members = await db.query.groupMemberships.findMany({
+        where: eq(groupMemberships.groupId, input.groupId),
+        with: { user: { columns: { id: true, name: true, username: true } } },
+      });
+      const memberIds = members.map((m) => m.userId);
+      if (!memberIds.includes(ctx.user.id)) {
+        throw new TRPCError({ code: "FORBIDDEN" });
+      }
+      // Get ownerships for this game among group members
+      const ownerships = await db.query.gameOwnerships.findMany({
+        where: and(
+          eq(gameOwnerships.gameId, input.gameId),
+          or(...memberIds.map((id) => eq(gameOwnerships.userId, id)))
+        ),
+        with: { user: { columns: { id: true, name: true, username: true } } },
+      });
+      return ownerships.map((o) => ({ user: o.user, platform: o.platform }));
+    }),
+});

--- a/src/server/trpc/routers/groups.ts
+++ b/src/server/trpc/routers/groups.ts
@@ -1,0 +1,144 @@
+import { z } from "zod";
+import { eq, and } from "drizzle-orm";
+import { TRPCError } from "@trpc/server";
+import { createId } from "@paralleldrive/cuid2";
+import { createTRPCRouter, protectedProcedure } from "@/server/trpc/trpc";
+import { db } from "@/server/db";
+import { groups, groupMemberships } from "@/server/db/schema";
+
+export const groupsRouter = createTRPCRouter({
+  // List groups the current user belongs to
+  list: protectedProcedure.query(async ({ ctx }) => {
+    const memberships = await db.query.groupMemberships.findMany({
+      where: eq(groupMemberships.userId, ctx.user.id),
+      with: {
+        group: true,
+      },
+    });
+    return memberships.map((m) => ({ ...m.group, role: m.role }));
+  }),
+
+  // Get a single group + its members (must be a member to view)
+  get: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .query(async ({ ctx, input }) => {
+      const membership = await db.query.groupMemberships.findFirst({
+        where: and(
+          eq(groupMemberships.groupId, input.id),
+          eq(groupMemberships.userId, ctx.user.id)
+        ),
+      });
+      if (!membership) {
+        throw new TRPCError({ code: "FORBIDDEN", message: "You are not a member of this group." });
+      }
+      const group = await db.query.groups.findFirst({
+        where: eq(groups.id, input.id),
+        with: {
+          memberships: {
+            with: {
+              user: {
+                columns: { id: true, name: true, username: true, image: true },
+              },
+            },
+          },
+        },
+      });
+      if (!group) throw new TRPCError({ code: "NOT_FOUND" });
+      return { ...group, myRole: membership.role };
+    }),
+
+  // Create a new group (CAMP-040)
+  create: protectedProcedure
+    .input(
+      z.object({
+        name: z.string().min(1).max(100),
+        description: z.string().max(500).optional(),
+        visibility: z.enum(["standard", "private"]).default("standard"),
+        discordInviteUrl: z.string().url().optional().or(z.literal("")),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const id = createId();
+      const inviteToken = createId();
+      await db.insert(groups).values({
+        id,
+        name: input.name,
+        description: input.description ?? null,
+        visibility: input.visibility,
+        discordInviteUrl: input.discordInviteUrl || null,
+        inviteToken,
+      });
+      await db.insert(groupMemberships).values({
+        groupId: id,
+        userId: ctx.user.id,
+        role: "owner",
+      });
+      return { id };
+    }),
+
+  // Join via invite token (CAMP-042)
+  join: protectedProcedure
+    .input(z.object({ inviteToken: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const group = await db.query.groups.findFirst({
+        where: eq(groups.inviteToken, input.inviteToken),
+        columns: { id: true, name: true },
+      });
+      if (!group) throw new TRPCError({ code: "NOT_FOUND", message: "Invalid invite link." });
+
+      const existing = await db.query.groupMemberships.findFirst({
+        where: and(
+          eq(groupMemberships.groupId, group.id),
+          eq(groupMemberships.userId, ctx.user.id)
+        ),
+      });
+      if (existing) throw new TRPCError({ code: "CONFLICT", message: "Already a member." });
+
+      await db.insert(groupMemberships).values({
+        groupId: group.id,
+        userId: ctx.user.id,
+        role: "member",
+      });
+      return { id: group.id };
+    }),
+
+  // Leave a group (CAMP-045)
+  leave: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const membership = await db.query.groupMemberships.findFirst({
+        where: and(
+          eq(groupMemberships.groupId, input.id),
+          eq(groupMemberships.userId, ctx.user.id)
+        ),
+      });
+      if (!membership) throw new TRPCError({ code: "NOT_FOUND" });
+      if (membership.role === "owner") {
+        throw new TRPCError({ code: "BAD_REQUEST", message: "Transfer ownership before leaving." });
+      }
+      await db.delete(groupMemberships).where(
+        and(
+          eq(groupMemberships.groupId, input.id),
+          eq(groupMemberships.userId, ctx.user.id)
+        )
+      );
+    }),
+
+  // Get invite token for sharing (members only)
+  getInviteToken: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .query(async ({ ctx, input }) => {
+      const membership = await db.query.groupMemberships.findFirst({
+        where: and(
+          eq(groupMemberships.groupId, input.id),
+          eq(groupMemberships.userId, ctx.user.id)
+        ),
+      });
+      if (!membership) throw new TRPCError({ code: "FORBIDDEN" });
+      const group = await db.query.groups.findFirst({
+        where: eq(groups.id, input.id),
+        columns: { inviteToken: true },
+      });
+      return { inviteToken: group?.inviteToken ?? null };
+    }),
+});

--- a/src/server/trpc/routers/notifications.ts
+++ b/src/server/trpc/routers/notifications.ts
@@ -1,0 +1,52 @@
+import { z } from "zod";
+import { and, desc, eq, isNull } from "drizzle-orm";
+import { createTRPCRouter, protectedProcedure } from "@/server/trpc/trpc";
+import { db } from "@/server/db";
+import { notifications } from "@/server/db/schema";
+
+export const notificationsRouter = createTRPCRouter({
+  // Unread count for the bell badge (CAMP-120)
+  unreadCount: protectedProcedure.query(async ({ ctx }) => {
+    const rows = await db.query.notifications.findMany({
+      where: and(
+        eq(notifications.userId, ctx.user.id),
+        isNull(notifications.readAt)
+      ),
+      columns: { id: true },
+    });
+    return { count: rows.length };
+  }),
+
+  // Full list, newest first (CAMP-120)
+  list: protectedProcedure
+    .input(z.object({ limit: z.number().min(1).max(50).default(30) }))
+    .query(async ({ ctx, input }) => {
+      return db.query.notifications.findMany({
+        where: eq(notifications.userId, ctx.user.id),
+        orderBy: [desc(notifications.createdAt)],
+        limit: input.limit,
+      });
+    }),
+
+  // Mark a single notification read
+  markRead: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      await db
+        .update(notifications)
+        .set({ readAt: new Date() })
+        .where(
+          and(eq(notifications.id, input.id), eq(notifications.userId, ctx.user.id))
+        );
+    }),
+
+  // Mark all read (CAMP-120)
+  markAllRead: protectedProcedure.mutation(async ({ ctx }) => {
+    await db
+      .update(notifications)
+      .set({ readAt: new Date() })
+      .where(
+        and(eq(notifications.userId, ctx.user.id), isNull(notifications.readAt))
+      );
+  }),
+});

--- a/src/server/trpc/routers/polls.ts
+++ b/src/server/trpc/routers/polls.ts
@@ -1,0 +1,258 @@
+import { z } from "zod";
+import { and, eq } from "drizzle-orm";
+import { TRPCError } from "@trpc/server";
+import { createId } from "@paralleldrive/cuid2";
+import { createTRPCRouter, protectedProcedure } from "@/server/trpc/trpc";
+import { db } from "@/server/db";
+import { polls, pollOptions, pollVotes, events, groupMemberships, groups } from "@/server/db/schema";
+import { enqueuePollOpened, enqueuePollClosed } from "@/server/jobs/email-jobs";
+
+async function assertPollMember(pollId: string, userId: string) {
+  const poll = await db.query.polls.findFirst({ where: eq(polls.id, pollId) });
+  if (!poll) throw new TRPCError({ code: "NOT_FOUND" });
+
+  // Resolve the group for this poll
+  const groupId = poll.groupId ?? (poll.eventId
+    ? (await db.query.events.findFirst({ where: eq(events.id, poll.eventId) }))?.groupId
+    : null);
+
+  if (!groupId) throw new TRPCError({ code: "NOT_FOUND" });
+
+  const m = await db.query.groupMemberships.findFirst({
+    where: and(eq(groupMemberships.groupId, groupId), eq(groupMemberships.userId, userId)),
+  });
+  if (!m) throw new TRPCError({ code: "FORBIDDEN" });
+
+  return { poll, groupId };
+}
+
+const POLL_TYPES = ["time_slot", "game", "duration", "custom"] as const;
+
+const pollOptionInput = z.object({
+  label: z.string().min(1).max(200),
+  gameId: z.string().optional(),
+  startsAt: z.string().datetime().optional(),
+  endsAt: z.string().datetime().optional(),
+  sortOrder: z.number().int().default(0),
+});
+
+export const pollsRouter = createTRPCRouter({
+  // Create a poll (attached to event or standalone group poll) (CAMP-062)
+  create: protectedProcedure
+    .input(
+      z.object({
+        eventId: z.string().optional(),
+        groupId: z.string().optional(),
+        type: z.enum(POLL_TYPES),
+        question: z.string().min(1).max(300),
+        allowMultipleVotes: z.boolean().default(false),
+        closesAt: z.string().datetime().optional(),
+        options: z.array(pollOptionInput).min(2).max(20),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      if (!input.eventId && !input.groupId) {
+        throw new TRPCError({ code: "BAD_REQUEST", message: "Provide eventId or groupId." });
+      }
+
+      // Determine the group to check membership
+      let groupId = input.groupId;
+      if (input.eventId && !groupId) {
+        const event = await db.query.events.findFirst({ where: eq(events.id, input.eventId) });
+        if (!event) throw new TRPCError({ code: "NOT_FOUND" });
+        groupId = event.groupId;
+      }
+
+      const m = await db.query.groupMemberships.findFirst({
+        where: and(
+          eq(groupMemberships.groupId, groupId!),
+          eq(groupMemberships.userId, ctx.user.id)
+        ),
+      });
+      if (!m) throw new TRPCError({ code: "FORBIDDEN" });
+
+      const id = createId();
+      await db.insert(polls).values({
+        id,
+        eventId: input.eventId ?? null,
+        groupId: input.groupId ?? null,
+        type: input.type,
+        question: input.question,
+        allowMultipleVotes: input.allowMultipleVotes ? "true" : "false",
+        closesAt: input.closesAt ? new Date(input.closesAt) : null,
+        status: "open",
+        createdBy: ctx.user.id,
+      });
+
+      for (const [i, opt] of input.options.entries()) {
+        await db.insert(pollOptions).values({
+          id: createId(),
+          pollId: id,
+          label: opt.label,
+          gameId: opt.gameId ?? null,
+          startsAt: opt.startsAt ? new Date(opt.startsAt) : null,
+          endsAt: opt.endsAt ? new Date(opt.endsAt) : null,
+          sortOrder: opt.sortOrder ?? i,
+        });
+      }
+
+      // Notify group members that a new poll is open
+      const group = await db.query.groups.findFirst({
+        where: eq(groups.id, groupId!),
+        columns: { name: true },
+      });
+      const members = await db.query.groupMemberships.findMany({
+        where: eq(groupMemberships.groupId, groupId!),
+        columns: { userId: true },
+      });
+      let eventTitle: string | undefined;
+      if (input.eventId) {
+        const ev = await db.query.events.findFirst({
+          where: eq(events.id, input.eventId),
+          columns: { title: true },
+        });
+        eventTitle = ev?.title;
+      }
+      void enqueuePollOpened({
+        pollId: id,
+        pollQuestion: input.question,
+        groupName: group?.name ?? "your group",
+        eventTitle,
+        recipientUserIds: members.map((m) => m.userId).filter((uid) => uid !== ctx.user.id),
+      });
+
+      return { id };
+    }),
+
+  // Get a poll with options and vote counts
+  get: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .query(async ({ ctx, input }) => {
+      await assertPollMember(input.id, ctx.user.id);
+
+      const full = await db.query.polls.findFirst({
+        where: eq(polls.id, input.id),
+        with: {
+          createdBy: { columns: { id: true, name: true, username: true } },
+          options: {
+            with: {
+              votes: { columns: { userId: true } },
+              game: { columns: { id: true, title: true } },
+            },
+            orderBy: (t, { asc }) => [asc(t.sortOrder)],
+          },
+        },
+      });
+      if (!full) throw new TRPCError({ code: "NOT_FOUND" });
+
+      // Mark which options the current user voted for
+      const myVotes = new Set(
+        full.options.flatMap((o) =>
+          o.votes.filter((v) => v.userId === ctx.user.id).map(() => o.id)
+        )
+      );
+
+      return {
+        ...full,
+        allowMultipleVotes: full.allowMultipleVotes === "true",
+        options: full.options.map((o) => ({
+          ...o,
+          voteCount: o.votes.length,
+          iVoted: myVotes.has(o.id),
+        })),
+      };
+    }),
+
+  // Vote on a poll option (CAMP-063)
+  vote: protectedProcedure
+    .input(z.object({ pollOptionId: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const option = await db.query.pollOptions.findFirst({
+        where: eq(pollOptions.id, input.pollOptionId),
+      });
+      if (!option) throw new TRPCError({ code: "NOT_FOUND" });
+
+      const { poll } = await assertPollMember(option.pollId, ctx.user.id);
+      if (poll.status === "closed") {
+        throw new TRPCError({ code: "BAD_REQUEST", message: "Poll is closed." });
+      }
+
+      const existing = await db.query.pollVotes.findFirst({
+        where: and(
+          eq(pollVotes.pollOptionId, input.pollOptionId),
+          eq(pollVotes.userId, ctx.user.id)
+        ),
+      });
+
+      if (existing) {
+        // Toggle off
+        await db
+          .delete(pollVotes)
+          .where(
+            and(
+              eq(pollVotes.pollOptionId, input.pollOptionId),
+              eq(pollVotes.userId, ctx.user.id)
+            )
+          );
+        return { voted: false };
+      }
+
+      // If single-vote poll, remove any existing votes on other options first
+      if (poll.allowMultipleVotes !== "true") {
+        const siblings = await db.query.pollOptions.findMany({
+          where: eq(pollOptions.pollId, option.pollId),
+          columns: { id: true },
+        });
+        for (const sib of siblings) {
+          await db
+            .delete(pollVotes)
+            .where(
+              and(eq(pollVotes.pollOptionId, sib.id), eq(pollVotes.userId, ctx.user.id))
+            );
+        }
+      }
+
+      await db.insert(pollVotes).values({
+        pollOptionId: input.pollOptionId,
+        userId: ctx.user.id,
+      });
+      return { voted: true };
+    }),
+
+  // Close a poll manually (creator only) (CAMP-064)
+  close: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const { poll, groupId } = await assertPollMember(input.id, ctx.user.id);
+      if (poll.createdBy !== ctx.user.id) throw new TRPCError({ code: "FORBIDDEN" });
+      await db.update(polls).set({ status: "closed" }).where(eq(polls.id, input.id));
+
+      // Notify users who voted that the poll is closed
+      const [group, voters] = await Promise.all([
+        db.query.groups.findFirst({
+          where: eq(groups.id, groupId),
+          columns: { name: true },
+        }),
+        db.query.pollVotes.findMany({
+          where: (pv, { inArray: inArr }) =>
+            inArr(
+              pv.pollOptionId,
+              db
+                .select({ id: pollOptions.id })
+                .from(pollOptions)
+                .where(eq(pollOptions.pollId, input.id))
+            ),
+          columns: { userId: true },
+        }),
+      ]);
+      const voterIds = [...new Set(voters.map((v) => v.userId))];
+      void enqueuePollClosed({
+        pollId: input.id,
+        pollQuestion: poll.question,
+        groupName: group?.name ?? "your group",
+        recipientUserIds: voterIds,
+      });
+
+      return { id: input.id };
+    }),
+});

--- a/src/server/trpc/routers/user.ts
+++ b/src/server/trpc/routers/user.ts
@@ -1,7 +1,69 @@
+import { z } from "zod";
+import { eq } from "drizzle-orm";
+import { TRPCError } from "@trpc/server";
 import { createTRPCRouter, protectedProcedure } from "@/server/trpc/trpc";
+import { db } from "@/server/db";
+import { user, type NotificationPrefs } from "@/server/db/schema";
+
+const notificationPrefsSchema = z.object({
+  friendRequestReceived: z.boolean().optional(),
+  friendRequestAccepted: z.boolean().optional(),
+  groupInviteReceived: z.boolean().optional(),
+  emailFriendRequest: z.boolean().optional(),
+  emailEventConfirmed: z.boolean().optional(),
+  emailEventCancelled: z.boolean().optional(),
+  emailEventRsvpReminder: z.boolean().optional(),
+  emailPollOpened: z.boolean().optional(),
+  emailPollClosed: z.boolean().optional(),
+  emailGroupInvite: z.boolean().optional(),
+}) satisfies z.ZodType<NotificationPrefs>;
+
+const USERNAME_RE = /^[a-z0-9_]{3,20}$/;
 
 export const userRouter = createTRPCRouter({
-  me: protectedProcedure.query(({ ctx }) => {
-    return ctx.user;
+  me: protectedProcedure.query(async ({ ctx }) => {
+    return db.query.user.findFirst({
+      where: eq(user.id, ctx.user.id),
+      columns: {
+        id: true,
+        name: true,
+        email: true,
+        image: true,
+        username: true,
+        bio: true,
+        profileVisibility: true,
+        notificationPrefs: true,
+        createdAt: true,
+      },
+    });
   }),
+
+  updateNotificationPrefs: protectedProcedure
+    .input(notificationPrefsSchema)
+    .mutation(async ({ ctx, input }) => {
+      const current = await db.query.user.findFirst({
+        where: eq(user.id, ctx.user.id),
+        columns: { notificationPrefs: true },
+      });
+      const merged: NotificationPrefs = { ...(current?.notificationPrefs ?? {}), ...input };
+      await db.update(user).set({ notificationPrefs: merged }).where(eq(user.id, ctx.user.id));
+      return { ok: true };
+    }),
+
+  setUsername: protectedProcedure
+    .input(z.object({ username: z.string().regex(USERNAME_RE, "3–20 chars, lowercase letters, numbers and underscores only") }))
+    .mutation(async ({ ctx, input }) => {
+      // Check uniqueness
+      const existing = await db.query.user.findFirst({
+        where: eq(user.username, input.username),
+        columns: { id: true },
+      });
+      if (existing && existing.id !== ctx.user.id) {
+        throw new TRPCError({ code: "CONFLICT", message: "That username is already taken." });
+      }
+      await db
+        .update(user)
+        .set({ username: input.username, usernameChangedAt: new Date() })
+        .where(eq(user.id, ctx.user.id));
+    }),
 });

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1,19 +1,20 @@
 import { Worker, Queue } from "bullmq";
 import { bullmqConnection } from "@/server/redis";
+import { processEmailJob } from "./processors/email";
+import type { EmailJobPayload } from "@/server/jobs/email-jobs";
 
 // Queue definitions — imported by other modules to enqueue jobs
-export const emailQueue = new Queue("email", { connection: bullmqConnection });
+export const emailQueue = new Queue<EmailJobPayload>("email", { connection: bullmqConnection });
 export const imageQueue = new Queue("image-processing", {
   connection: bullmqConnection,
 });
 export const ogQueue = new Queue("og-fetch", { connection: bullmqConnection });
 
 // Email worker
-new Worker(
+new Worker<EmailJobPayload>(
   "email",
   async (job) => {
-    // TODO: implement email sending via nodemailer
-    console.log("Processing email job:", job.id, job.data);
+    await processEmailJob(job);
   },
   { connection: bullmqConnection }
 );

--- a/src/worker/processors/email.ts
+++ b/src/worker/processors/email.ts
@@ -1,0 +1,216 @@
+import type { Job } from "bullmq";
+import { inArray, eq } from "drizzle-orm";
+import { db } from "@/server/db";
+import { user } from "@/server/db/schema";
+import type { NotificationPrefs } from "@/server/db/schema";
+import { sendEmail } from "@/server/email";
+import type { EmailJobPayload } from "@/server/jobs/email-jobs";
+import { env } from "@/env";
+
+type Prefs = NotificationPrefs;
+
+const appUrl = () => env.NEXT_PUBLIC_APP_URL;
+
+// ── Preference defaults (mirrors settings page) ───────────────────────────────
+
+const DEFAULTS: Required<Prefs> = {
+  friendRequestReceived: true,
+  friendRequestAccepted: true,
+  groupInviteReceived: true,
+  emailFriendRequest: false,
+  emailEventConfirmed: true,
+  emailEventCancelled: true,
+  emailEventRsvpReminder: true,
+  emailPollOpened: true,
+  emailPollClosed: false,
+  emailGroupInvite: true,
+};
+
+function pref(prefs: Prefs | null | undefined, key: keyof Required<Prefs>): boolean {
+  if (prefs && key in prefs) return prefs[key] as boolean;
+  return DEFAULTS[key];
+}
+
+// ── Simple HTML email template ────────────────────────────────────────────────
+
+function htmlEmail(title: string, bodyHtml: string, ctaUrl?: string, ctaLabel?: string) {
+  const cta = ctaUrl
+    ? `<p style="margin-top:24px"><a href="${ctaUrl}" style="background:#e05f1a;color:#fff;padding:10px 20px;border-radius:6px;text-decoration:none;font-weight:600">${ctaLabel ?? "View"}</a></p>`
+    : "";
+  return `<!DOCTYPE html><html><body style="font-family:sans-serif;max-width:560px;margin:0 auto;padding:24px;color:#1a1a1a">
+<h2 style="margin-top:0">${title}</h2>
+${bodyHtml}
+${cta}
+<hr style="margin-top:40px;border:none;border-top:1px solid #e5e5e5"/>
+<p style="font-size:12px;color:#888">You're receiving this because you have email notifications enabled for Campfire. <a href="${appUrl()}/settings">Manage preferences</a></p>
+</body></html>`;
+}
+
+// ── Fetch recipients with prefs ───────────────────────────────────────────────
+
+async function getRecipients(userIds: string[]) {
+  if (userIds.length === 0) return [];
+  return db.query.user.findMany({
+    where: inArray(user.id, userIds),
+    columns: { id: true, name: true, email: true, notificationPrefs: true },
+  });
+}
+
+async function getSingleRecipient(userId: string) {
+  return db.query.user.findFirst({
+    where: eq(user.id, userId),
+    columns: { id: true, name: true, email: true, notificationPrefs: true },
+  });
+}
+
+// ── Processor ─────────────────────────────────────────────────────────────────
+
+export async function processEmailJob(job: Job<EmailJobPayload>) {
+  const data = job.data;
+
+  switch (data.type) {
+    case "event_confirmed": {
+      const recipients = await getRecipients(data.recipientUserIds);
+      const dateStr = new Date(data.confirmedStartsAt).toLocaleString("en-GB", {
+        weekday: "long", day: "numeric", month: "long", year: "numeric",
+        hour: "2-digit", minute: "2-digit",
+      });
+      const endsStr = data.confirmedEndsAt
+        ? ` – ${new Date(data.confirmedEndsAt).toLocaleTimeString("en-GB", { hour: "2-digit", minute: "2-digit" })}`
+        : "";
+      for (const r of recipients) {
+        if (!pref(r.notificationPrefs as Prefs, "emailEventConfirmed")) continue;
+        await sendEmail({
+          to: r.email,
+          subject: `Event confirmed: ${data.eventTitle}`,
+          text: `Hi ${r.name},\n\n"${data.eventTitle}" in ${data.groupName} has been confirmed for ${dateStr}${endsStr}.\n\nView event: ${appUrl()}/events/${data.eventId}`,
+          html: htmlEmail(
+            `Event confirmed: ${data.eventTitle}`,
+            `<p>Hi ${r.name},</p><p><strong>${data.eventTitle}</strong> in <strong>${data.groupName}</strong> has been confirmed for <strong>${dateStr}${endsStr}</strong>.</p>`,
+            `${appUrl()}/events/${data.eventId}`,
+            "View event"
+          ),
+        });
+      }
+      break;
+    }
+
+    case "event_cancelled": {
+      const recipients = await getRecipients(data.recipientUserIds);
+      for (const r of recipients) {
+        if (!pref(r.notificationPrefs as Prefs, "emailEventCancelled")) continue;
+        await sendEmail({
+          to: r.email,
+          subject: `Event cancelled: ${data.eventTitle}`,
+          text: `Hi ${r.name},\n\nUnfortunately "${data.eventTitle}" in ${data.groupName} has been cancelled.\n\nView group: ${appUrl()}/groups`,
+          html: htmlEmail(
+            `Event cancelled: ${data.eventTitle}`,
+            `<p>Hi ${r.name},</p><p>Unfortunately <strong>${data.eventTitle}</strong> in <strong>${data.groupName}</strong> has been cancelled.</p>`,
+            `${appUrl()}/events/${data.eventId}`,
+            "View event"
+          ),
+        });
+      }
+      break;
+    }
+
+    case "event_rsvp_reminder": {
+      const recipients = await getRecipients(data.recipientUserIds);
+      for (const r of recipients) {
+        if (!pref(r.notificationPrefs as Prefs, "emailEventRsvpReminder")) continue;
+        await sendEmail({
+          to: r.email,
+          subject: `RSVP reminder: ${data.eventTitle}`,
+          text: `Hi ${r.name},\n\nHave you had a chance to RSVP to "${data.eventTitle}" in ${data.groupName}?\n\nView event: ${appUrl()}/events/${data.eventId}`,
+          html: htmlEmail(
+            `RSVP reminder: ${data.eventTitle}`,
+            `<p>Hi ${r.name},</p><p>Have you had a chance to RSVP to <strong>${data.eventTitle}</strong> in <strong>${data.groupName}</strong>?</p>`,
+            `${appUrl()}/events/${data.eventId}`,
+            "RSVP now"
+          ),
+        });
+      }
+      break;
+    }
+
+    case "poll_opened": {
+      const recipients = await getRecipients(data.recipientUserIds);
+      const context = data.eventTitle ? ` for "${data.eventTitle}"` : "";
+      for (const r of recipients) {
+        if (!pref(r.notificationPrefs as Prefs, "emailPollOpened")) continue;
+        await sendEmail({
+          to: r.email,
+          subject: `New poll${context}: ${data.pollQuestion}`,
+          text: `Hi ${r.name},\n\nA new poll has been opened in ${data.groupName}${context}:\n\n"${data.pollQuestion}"\n\nCast your vote: ${appUrl()}/events/${data.pollId}`,
+          html: htmlEmail(
+            `New poll in ${data.groupName}`,
+            `<p>Hi ${r.name},</p><p>A new poll has been opened${context}:</p><blockquote style="border-left:3px solid #e05f1a;margin:16px 0;padding:8px 16px;color:#444">${data.pollQuestion}</blockquote>`,
+            `${appUrl()}/events/${data.pollId}`,
+            "Vote now"
+          ),
+        });
+      }
+      break;
+    }
+
+    case "poll_closed": {
+      const recipients = await getRecipients(data.recipientUserIds);
+      for (const r of recipients) {
+        if (!pref(r.notificationPrefs as Prefs, "emailPollClosed")) continue;
+        await sendEmail({
+          to: r.email,
+          subject: `Poll closed: ${data.pollQuestion}`,
+          text: `Hi ${r.name},\n\nThe poll "${data.pollQuestion}" in ${data.groupName} has been closed. Check the results!\n\nView results: ${appUrl()}/events/${data.pollId}`,
+          html: htmlEmail(
+            `Poll closed: results are in`,
+            `<p>Hi ${r.name},</p><p>The poll <strong>"${data.pollQuestion}"</strong> in <strong>${data.groupName}</strong> has been closed.</p>`,
+            `${appUrl()}/events/${data.pollId}`,
+            "View results"
+          ),
+        });
+      }
+      break;
+    }
+
+    case "group_invite": {
+      const r = await getSingleRecipient(data.recipientUserId);
+      if (!r) break;
+      if (!pref(r.notificationPrefs as Prefs, "emailGroupInvite")) break;
+      await sendEmail({
+        to: r.email,
+        subject: `You've been invited to ${data.groupName}`,
+        text: `Hi ${r.name},\n\n${data.inviterName} has invited you to join "${data.groupName}" on Campfire.\n\nJoin: ${appUrl()}/groups/${data.groupId}`,
+        html: htmlEmail(
+          `You've been invited to ${data.groupName}`,
+          `<p>Hi ${r.name},</p><p><strong>${data.inviterName}</strong> has invited you to join <strong>${data.groupName}</strong> on Campfire.</p>`,
+          `${appUrl()}/groups/${data.groupId}`,
+          "View group"
+        ),
+      });
+      break;
+    }
+
+    case "friend_request": {
+      const r = await getSingleRecipient(data.recipientUserId);
+      if (!r) break;
+      if (!pref(r.notificationPrefs as Prefs, "emailFriendRequest")) break;
+      await sendEmail({
+        to: r.email,
+        subject: `${data.requesterName} sent you a friend request`,
+        text: `Hi ${r.name},\n\n${data.requesterName} sent you a friend request on Campfire.\n\nRespond: ${appUrl()}/friends`,
+        html: htmlEmail(
+          `New friend request`,
+          `<p>Hi ${r.name},</p><p><strong>${data.requesterName}</strong> sent you a friend request on Campfire.</p>`,
+          `${appUrl()}/friends`,
+          "Respond"
+        ),
+      });
+      break;
+    }
+
+    default: {
+      const _exhaustive: never = data;
+      console.warn("Unknown email job type:", (_exhaustive as { type: string }).type);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements Phase 1 features on top of the Phase 0 scaffold.

### Phase 1-A — Auth & Onboarding
- Registration, login, logout via better-auth
- Onboarding flow (username → bio → invite link)
- Friends system: send/accept/decline requests, friends list

### Phase 1-B — Games Library
- Add games to personal library (with platform tag)
- Filter by platform, remove games
- Games nav link

### Phase 1-C — Availability
- Week view with Mon–Sun navigation
- Add / edit / delete time blocks with label and visibility (friends / group / private)
- Group overlap view procedure wired (UI pending — TD-019)

### Phase 1-D — Events & Polls
- Create events per group with title, description, optional game
- Event lifecycle: draft → open → confirmed → cancelled
- Confirm dialog collects start/end datetime
- RSVP (Going / Maybe / Not going) with live counts
- Poll creation (single-choice / multi-choice) attached to events
- Poll voting with live percentage bars, toggle behaviour
- Poll close (creator only), `closesAt` field stored (auto-close job pending — TD-020)

### Phase 1-E — Notifications & Settings
- In-app notification bell with unread badge
- Notifications page: mark all read on load, dismiss individual, accept/decline friend requests inline
- Settings page: username edit, display name (cosmetic — TD-018), per-category notification toggles
- `notificationPrefs` JSONB on user table; all categories default on

### Phase 1-F — BullMQ Email Jobs
- `emailQueue` + typed `EmailJobPayload` discriminated union
- Jobs: event confirmed, event cancelled, RSVP reminder (24 h before), poll opened, poll closed
- Worker processor checks per-user prefs before sending; falls back to defaults (all on)
- HTML email template with CTA button via Nodemailer → Mailhog in dev

### Bug fixes
- "Failed to get session" crash on hot-reload: app layout now catches the error and redirects to `/login`
- Event confirm: replaced inline button with a dialog that collects datetime before confirming
- Notifications page: `markAllRead` / `unreadCount` invalidation fixed

### Docs
- `DEV_NOTES.md`: session notes, features built table
- `docs/TECH_DEBT.md`: marked TD-001/TD-002 fixed; added TD-018 through TD-023

## Test plan

1. `docker-compose up -d` → `pnpm db:migrate` → `pnpm db:seed`
2. Log in as alice / bob / carol (password: `password123`)
3. Add games, check platform filter
4. Set availability blocks for the week
5. Create an event in Friday Night Squad; RSVP as another user
6. Confirm the event (as alice); check Mailhog for confirmation emails
7. Create a poll; vote as two users; close poll; check Mailhog for closed emails
8. Check notification bell badge clears on visiting /notifications
9. Toggle email prefs off in Settings; confirm event → no email sent for that user
10. `pnpm typecheck && pnpm lint && pnpm test:run` — all green

## Notes

- `gh` CLI not available in this environment; PR created manually via browser
- TD-018 (display name mutation) intentionally deferred
- TD-019 (group overlap UI) intentionally deferred
- TD-020 (poll auto-close job) intentionally deferred