### PR TITLE
feat(CAMP-022/023): profile invite links

### DIFF
--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -67,6 +67,63 @@ function mergePrefs(saved: NotificationPrefs | undefined): Required<Notification
   return { ...PREF_DEFAULTS, ...(saved ?? {}) };
 }
 
+// ── Invite section ────────────────────────────────────────────────────────────
+
+function InviteSection() {
+  const { data, refetch } = api.user.getInviteToken.useQuery();
+  const regenerate = api.user.regenerateInviteToken.useMutation({
+    onSuccess: () => void refetch(),
+  });
+  const [copied, setCopied] = useState(false);
+
+  const inviteUrl = typeof window !== "undefined" && data?.token
+    ? `${window.location.origin}/invite/${data.token}`
+    : "";
+
+  function handleCopy() {
+    if (!inviteUrl) return;
+    void navigator.clipboard.writeText(inviteUrl).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }
+
+  return (
+    <section className="space-y-4">
+      <h2 className="text-base font-semibold border-b pb-2">Invite a friend</h2>
+      <p className="text-sm text-muted-foreground">
+        Share your personal invite link. Anyone who visits it can send you a friend request.
+        Regenerating the link invalidates the old one.
+      </p>
+      {data?.token ? (
+        <div className="space-y-2">
+          <div className="flex gap-2">
+            <Input readOnly value={inviteUrl} className="font-mono text-xs" />
+            <Button variant="outline" onClick={handleCopy} className="shrink-0">
+              {copied ? "Copied!" : "Copy"}
+            </Button>
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-xs text-muted-foreground"
+            disabled={regenerate.isPending}
+            onClick={() => {
+              if (window.confirm("Regenerate your invite link? The old link will stop working.")) {
+                regenerate.mutate();
+              }
+            }}
+          >
+            {regenerate.isPending ? "Regenerating…" : "Regenerate link"}
+          </Button>
+        </div>
+      ) : (
+        <p className="text-sm text-muted-foreground">Generating link…</p>
+      )}
+    </section>
+  );
+}
+
 // ── Settings page ─────────────────────────────────────────────────────────────
 
 export default function SettingsPage() {
@@ -155,6 +212,9 @@ export default function SettingsPage() {
           <p className="text-sm text-muted-foreground">{me?.email ?? "—"}</p>
         </div>
       </section>
+
+      {/* ── Invite a friend ──────────────────────────────────────────────────── */}
+      <InviteSection />
 
       {/* ── Notifications ────────────────────────────────────────────────────── */}
       <section className="space-y-1">

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { Suspense, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { authClient } from "@/lib/auth-client";
 import { Button } from "@/components/ui/button";
@@ -16,8 +16,11 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 
-export default function LoginPage() {
+function LoginForm() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const callbackUrl = searchParams.get("callbackUrl") ?? "/feed";
+
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
@@ -28,10 +31,7 @@ export default function LoginPage() {
     setError("");
     setLoading(true);
 
-    const { error } = await authClient.signIn.email({
-      email,
-      password,
-    });
+    const { error } = await authClient.signIn.email({ email, password });
 
     if (error) {
       setError(error.message ?? "Invalid email or password.");
@@ -39,7 +39,7 @@ export default function LoginPage() {
       return;
     }
 
-    router.push("/feed");
+    router.push(callbackUrl);
     router.refresh();
   }
 
@@ -106,5 +106,13 @@ export default function LoginPage() {
         </form>
       </Card>
     </div>
+  );
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense fallback={null}>
+      <LoginForm />
+    </Suspense>
   );
 }

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { use } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import { api } from "@/trpc/react";
+import { Button } from "@/components/ui/button";
+
+export default function InvitePage({ params }: { params: Promise<{ token: string }> }) {
+  const { token } = use(params);
+
+  // Resolve the token to the inviter's public profile (no auth required)
+  const { data: inviter, isPending: resolving, error } = api.friends.resolveInviteToken.useQuery({ token });
+
+  // Check if the current visitor is logged in
+  const { data: me, isPending: loadingMe } = api.user.me.useQuery();
+
+  const sendRequest = api.friends.sendRequestViaToken.useMutation();
+
+  const isLoading = resolving || loadingMe;
+  const alreadySent = sendRequest.isSuccess;
+  const isSelf = me && inviter && me.id === inviter.id;
+
+  // Determine friendship state from the CONFLICT error
+  const alreadyFriends = sendRequest.error?.data?.code === "CONFLICT";
+
+  return (
+    <div className="flex min-h-screen flex-col bg-background">
+      {/* Minimal header */}
+      <header className="border-b px-4">
+        <div className="mx-auto flex h-14 max-w-md items-center">
+          <Link href="/feed" className="text-lg font-semibold tracking-tight">
+            Campfire
+          </Link>
+        </div>
+      </header>
+
+      <main className="flex flex-1 items-center justify-center px-4 py-12">
+        <div className="w-full max-w-sm space-y-6 text-center">
+
+          {isLoading && (
+            <p className="text-muted-foreground">Loading…</p>
+          )}
+
+          {!isLoading && error && (
+            <div className="space-y-3">
+              <p className="text-lg font-semibold">Link not found</p>
+              <p className="text-sm text-muted-foreground">
+                This invite link may have been regenerated or doesn&apos;t exist.
+              </p>
+              <Button asChild variant="outline">
+                <Link href="/">Go to Campfire</Link>
+              </Button>
+            </div>
+          )}
+
+          {!isLoading && inviter && (
+            <div className="space-y-5">
+              {/* Inviter avatar + name */}
+              <div className="flex flex-col items-center gap-3">
+                {inviter.image ? (
+                  <Image
+                    src={inviter.image}
+                    alt={inviter.name}
+                    width={72}
+                    height={72}
+                    className="rounded-full border"
+                  />
+                ) : (
+                  <div className="flex h-[72px] w-[72px] items-center justify-center rounded-full border bg-muted text-2xl font-bold text-muted-foreground">
+                    {inviter.name.charAt(0).toUpperCase()}
+                  </div>
+                )}
+                <div>
+                  <p className="text-xl font-semibold">{inviter.name}</p>
+                  {inviter.username && (
+                    <p className="text-sm text-muted-foreground">@{inviter.username}</p>
+                  )}
+                </div>
+              </div>
+
+              <p className="text-muted-foreground text-sm">
+                {inviter.name} invited you to connect on Campfire — a place to plan gaming sessions with friends.
+              </p>
+
+              {/* Action area */}
+              {isSelf ? (
+                <p className="text-sm text-muted-foreground italic">This is your own invite link.</p>
+              ) : me ? (
+                // Logged-in: show friend request button
+                <div className="space-y-2">
+                  {alreadySent || alreadyFriends ? (
+                    <p className="text-sm text-green-600 font-medium">
+                      {alreadyFriends ? "You're already connected!" : "Friend request sent!"}
+                    </p>
+                  ) : (
+                    <Button
+                      className="w-full"
+                      onClick={() => sendRequest.mutate({ token })}
+                      disabled={sendRequest.isPending}
+                    >
+                      {sendRequest.isPending ? "Sending…" : `Add ${inviter.name} as a friend`}
+                    </Button>
+                  )}
+                  {sendRequest.error && !alreadyFriends && (
+                    <p className="text-xs text-destructive">{sendRequest.error.message}</p>
+                  )}
+                  <Button asChild variant="ghost" size="sm" className="w-full">
+                    <Link href="/feed">Go to my feed</Link>
+                  </Button>
+                </div>
+              ) : (
+                // Not logged in: prompt to sign up or sign in
+                <div className="space-y-3">
+                  <Button asChild className="w-full">
+                    <Link href={`/register?callbackUrl=/invite/${token}`}>
+                      Create a Campfire account
+                    </Link>
+                  </Button>
+                  <Button asChild variant="outline" className="w-full">
+                    <Link href={`/login?callbackUrl=/invite/${token}`}>
+                      Sign in
+                    </Link>
+                  </Button>
+                  <p className="text-xs text-muted-foreground">
+                    Already have an account? Sign in to accept the invite.
+                  </p>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/server/trpc/routers/friends.ts
+++ b/src/server/trpc/routers/friends.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { and, eq, ilike, ne, or } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
 import { createId } from "@paralleldrive/cuid2";
-import { createTRPCRouter, protectedProcedure } from "@/server/trpc/trpc";
+import { createTRPCRouter, protectedProcedure, publicProcedure } from "@/server/trpc/trpc";
 import { db } from "@/server/db";
 import { user, friendships, notifications } from "@/server/db/schema";
 
@@ -197,5 +197,58 @@ export const friendsRouter = createTRPCRouter({
             eq(friendships.status, "blocked")
           )
         );
+    }),
+
+  // Resolve an invite token to a public profile — no auth required (CAMP-023)
+  resolveInviteToken: publicProcedure
+    .input(z.object({ token: z.string() }))
+    .query(async ({ input }) => {
+      const found = await db.query.user.findFirst({
+        where: eq(user.inviteToken, input.token),
+        columns: { id: true, name: true, username: true, image: true },
+      });
+      if (!found) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Invite link not found or has been regenerated." });
+      }
+      return found;
+    }),
+
+  // Send a friend request via invite token — requires auth (CAMP-022)
+  sendRequestViaToken: protectedProcedure
+    .input(z.object({ token: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const found = await db.query.user.findFirst({
+        where: eq(user.inviteToken, input.token),
+        columns: { id: true },
+      });
+      if (!found) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Invite link not found or has been regenerated." });
+      }
+      if (found.id === ctx.user.id) {
+        throw new TRPCError({ code: "BAD_REQUEST", message: "You cannot add yourself." });
+      }
+      const existing = await db.query.friendships.findFirst({
+        where: or(
+          and(eq(friendships.requesterId, ctx.user.id), eq(friendships.addresseeId, found.id)),
+          and(eq(friendships.requesterId, found.id), eq(friendships.addresseeId, ctx.user.id))
+        ),
+      });
+      if (existing) {
+        if (existing.status === "blocked") {
+          throw new TRPCError({ code: "FORBIDDEN", message: "Action not allowed." });
+        }
+        throw new TRPCError({ code: "CONFLICT", message: "Already friends or request pending." });
+      }
+      await db.insert(friendships).values({
+        requesterId: ctx.user.id,
+        addresseeId: found.id,
+        status: "pending",
+      });
+      await db.insert(notifications).values({
+        id: createId(),
+        userId: found.id,
+        type: "friend_request_received",
+        data: { requesterId: ctx.user.id, requesterName: ctx.user.name },
+      });
     }),
 });

--- a/src/server/trpc/routers/user.ts
+++ b/src/server/trpc/routers/user.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { eq } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
+import { createId } from "@paralleldrive/cuid2";
 import { createTRPCRouter, protectedProcedure } from "@/server/trpc/trpc";
 import { db } from "@/server/db";
 import { user, type NotificationPrefs } from "@/server/db/schema";
@@ -33,9 +34,29 @@ export const userRouter = createTRPCRouter({
         bio: true,
         profileVisibility: true,
         notificationPrefs: true,
+        inviteToken: true,
         createdAt: true,
       },
     });
+  }),
+
+  // Returns the user's invite token, generating one if it doesn't exist yet.
+  getInviteToken: protectedProcedure.query(async ({ ctx }) => {
+    const row = await db.query.user.findFirst({
+      where: eq(user.id, ctx.user.id),
+      columns: { inviteToken: true },
+    });
+    if (row?.inviteToken) return { token: row.inviteToken };
+    const token = createId();
+    await db.update(user).set({ inviteToken: token }).where(eq(user.id, ctx.user.id));
+    return { token };
+  }),
+
+  // Generates a new invite token, invalidating the old one.
+  regenerateInviteToken: protectedProcedure.mutation(async ({ ctx }) => {
+    const token = createId();
+    await db.update(user).set({ inviteToken: token }).where(eq(user.id, ctx.user.id));
+    return { token };
   }),
 
   updateNotificationPrefs: protectedProcedure


### PR DESCRIPTION
## Summary

- **Invite token** — each user gets a unique, reusable invite token (lazy-generated on first visit to Settings). Regenerating it invalidates the old link.
- **`/invite/[token]`** — public landing page (no auth required). Shows the inviter's avatar, name, and username. Logged-in visitors get a one-click "Add as friend" button; anonymous visitors get Sign in / Create account links that redirect back to the invite page after auth.
- **Settings page** — "Invite a friend" section with a copy-to-clipboard button and a regenerate button (with confirmation dialog).
- **Login page** — now reads a `callbackUrl` search param and redirects there after sign-in, enabling the `/invite/[token]` → login → back flow cleanly.

## tRPC additions

| Procedure | Auth | Description |
|---|---|---|
| `user.getInviteToken` | protected | Returns current token, generating one if missing |
| `user.regenerateInviteToken` | protected | Rotates token unconditionally |
| `friends.resolveInviteToken` | **public** | Resolves token → inviter profile |
| `friends.sendRequestViaToken` | protected | Sends friend request via token |

## Test plan

- [ ] Go to Settings → copy invite link → open in incognito: see inviter profile + sign up / sign in CTAs
- [ ] Sign in via the CTA → redirected back to invite page → click "Add as friend" → request sent
- [ ] Open invite link while already logged in → one-click add
- [ ] Clicking add on your own link shows "This is your own invite link"
- [ ] Already connected → shows "Already friends or request pending"
- [ ] Regenerate invite link → old link shows "Link not found"
- [ ] Login with `?callbackUrl=/foo` → redirects to `/foo` after sign-in

Closes #15, closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)