### PR TITLE
feat(CAMP-021): /u/[username] public profile page

### DIFF
--- a/.claude/rules/implementation-workflow.md
+++ b/.claude/rules/implementation-workflow.md
@@ -1,0 +1,24 @@
+# Implementation Workflow
+
+When asked to implement or modify something in ProjectCampfire:
+
+1. Read the relevant files before proposing changes.
+2. Restate the task in terms of the current product and phase.
+3. Identify the affected layers:
+   - UI
+   - routing/API
+   - business logic
+   - database/schema
+   - background jobs
+   - docs/tests
+4. If the request is ambiguous and affects behavior, schema, permissions, or architecture, pause and surface the ambiguity.
+5. Prefer the narrowest implementation that fits the current MVP.
+6. Do not widen scope unless explicitly requested.
+7. Do not introduce new dependencies without justification.
+8. Keep routers thin and business logic out of UI components.
+9. If product behavior, schema, or architecture changes, update the relevant docs.
+10. After implementation, summarize:
+   - what changed
+   - affected files
+   - risks
+   - what should be tested

--- a/.claude/rules/product-boundaries.md
+++ b/.claude/rules/product-boundaries.md
@@ -1,0 +1,62 @@
+# Product Boundaries
+
+ProjectCampfire is a private-first social planning app for friend groups who game together.
+
+## Core MVP Value
+
+The MVP helps users:
+- add friends
+- create private groups
+- share availability
+- schedule gaming sessions
+- vote on games and times
+- RSVP to sessions
+- keep related discussion in one place
+- view lightweight game context that supports planning
+
+The main loop is:
+
+1. know who is available
+2. decide what to play
+3. schedule the session
+4. discuss the plan in one place
+
+## MVP Scope Rules
+
+Prioritize features that directly improve the private friend-group planning loop.
+
+Game metadata and external integrations are supporting features, not the product core.
+
+When evaluating a feature or implementation, prefer the option that strengthens:
+- private social planning
+- friend/group coordination
+- scheduling clarity
+- lightweight discussion tied to plans and games
+
+## Do Not Expand MVP Into
+
+Do not introduce or optimize for:
+- public forums
+- public game communities
+- global social feeds
+- live chat
+- voice/video calling
+- repost systems
+- recommendation engines
+- popularity dashboards as a primary feature
+- complex profile showcase systems
+- board game support
+- moderation-heavy public interaction
+- deep dependence on third-party APIs
+
+## External Integrations
+
+Steam, Twitch, YouTube, store/pricing sources, and other platforms may enrich the product, but the app must still provide value without them.
+
+Do not make core user flows depend entirely on external integrations unless explicitly requested.
+
+## Decision Rule
+
+If a proposed feature does not directly improve the private friend-group planning loop, defer it unless explicitly approved.
+
+If a request is ambiguous, choose the narrower interpretation that best fits the MVP.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,33 @@
 # ProjectCampfire
 
-Gaming social + session planning app. Self-hosted, Docker Compose, TypeScript monorepo.
+ProjectCampfire is a private-first social planning app for friend groups who game together.
+
+It helps users:
+- add friends
+- create private groups
+- share availability
+- plan gaming sessions
+- vote on games and times
+- keep related discussion in one place
+- view lightweight game context as supporting information
+
+## Product Boundaries
+
+ProjectCampfire is **not** a broad public social network in MVP.
+
+Do not expand the MVP into:
+- public threads or public game communities
+- live chat, voice, or streaming infrastructure
+- recommendation engines
+- broad moderation-heavy public spaces
+- deep third-party platform dependence
+- unnecessary feed complexity
+
+For MVP, the core value is:
+
+**Helping friend groups decide what to play, when to play, who is available, and who already owns the game.**
+
+Game metadata, price/popularity data, and external integrations are supporting features, not the product core.
 
 ## Quick Start
 
@@ -17,6 +44,19 @@ pnpm worker                  # BullMQ worker (separate terminal)
 
 Next.js 15 (App Router) · tRPC v11 · Drizzle ORM · PostgreSQL 16 · Redis (Valkey) · **better-auth** · BullMQ · MinIO · Sharp · Nodemailer · shadcn/ui · Tailwind CSS v3
 
+## Working Style
+
+When making changes:
+- Read the relevant files first.
+- Prefer the smallest useful implementation.
+- Preserve existing architectural boundaries.
+- Do not introduce new dependencies without justification.
+- Do not widen MVP scope unless explicitly asked.
+- If a change affects product behavior, schema, or architecture, update docs.
+- Explain risks, assumptions, and follow-on work clearly.
+
+Prefer incremental delivery over large speculative refactors.
+
 ## Work Tracking
 
 **Source of truth: [GitHub Issues](https://github.com/Luke-Bradford/ProjectCampfire/issues)** with milestones per phase.
@@ -30,9 +70,12 @@ Next.js 15 (App Router) · tRPC v11 · Drizzle ORM · PostgreSQL 16 · Redis (Va
 
 - **Auth:** better-auth (not Lucia). User table is `user` (singular). Session uses `token` field.
 - **Schema:** All custom profile fields live on the `user` table. See `src/server/db/schema/auth.ts`.
-- **BullMQ:** Export `bullmqConnection` as a plain options object from `src/server/redis.ts`. Do NOT pass an IORedis instance to BullMQ (version conflict).
+- **Validation:** Validate all procedure inputs explicitly.
+- **tRPC:** Keep routers thin. Put business logic in server-side services/helpers, not UI components.
+- **Database access:** Do not place database logic in React presentation components.
+- **BullMQ:** Use background jobs only for slow, external, retryable, or async work (email, sync, processing). Export bullmqConnection as a plain options object from src/server/redis.ts.
 - **Lint:** Use `eslint src --max-warnings 0` directly (`next lint` is deprecated in Next.js 15).
-- **Env validation:** `src/env.ts` uses `@t3-oss/env-nextjs` with Zod v4. App crashes on startup if variables are missing.
+- **Env validation:** `src/env.ts` uses `@t3-oss/env-nextjs` with Zod v4. The app should fail fast if required variables are missing.
 
 ## Project Layout
 
@@ -79,3 +122,12 @@ docs/
 | `pnpm typecheck` | tsc --noEmit |
 | `pnpm test:run` | Vitest one-shot |
 | `pnpm lint` | ESLint |
+
+## Notes for AI Assistance
+
+- Before implementing anything substantial:
+- identify the affected files
+- check whether the task belongs in the current phase
+- avoid introducing future-phase behavior unless explicitly requested
+- keep solutions self-hosted and compatible with Docker Compose deployment
+- prefer maintainability and clarity over cleverness

--- a/docs/MVP_BOUNDARIES.md
+++ b/docs/MVP_BOUNDARIES.md
@@ -1,0 +1,71 @@
+# MVP Boundaries
+
+## MVP Goal
+
+ProjectCampfire MVP helps small friend groups plan gaming sessions together.
+
+The MVP must allow users to:
+- create an account
+- add friends
+- create private groups
+- set availability
+- create and manage gaming sessions
+- vote on game/time options
+- RSVP to sessions
+- discuss sessions in lightweight private threads
+- link a game to a session
+- view basic game information
+
+## In Scope
+
+- Authentication
+- User profiles
+- Friend requests and friend list
+- Private groups
+- Availability blocks
+- Session/event creation
+- Recurring sessions
+- Polls for game/time selection
+- RSVP tracking
+- Notifications for invites / changes / comments
+- Basic game records and search
+- Lightweight private discussion on groups/events
+
+## Supporting Features Allowed
+
+- Optional Steam account linking
+- Game ownership sync if privacy allows
+- Basic game metadata from approved sources
+- External links to store pages, trailers, official sites
+
+## Out of Scope
+
+- Public forums
+- Public game communities
+- Global activity feeds
+- Live chat
+- Voice/video calling
+- Reposts / resharing systems
+- Recommendation engine
+- Popularity dashboards
+- Price history charts
+- Twitch/YouTube watch party features
+- Board game support
+- Mobile app
+- Complex badges/showcases
+- Full cross-platform identity graph
+
+## Success Criteria
+
+The MVP is successful if a small group of friends can:
+1. add each other
+2. create a private group
+3. share availability
+4. schedule a session
+5. vote on what to play
+6. RSVP
+7. discuss the plan in one place
+
+## Rule
+
+If a feature does not directly improve the private friend-group planning loop, it should be deferred unless explicitly approved.

--- a/src/app/(app)/friends/page.tsx
+++ b/src/app/(app)/friends/page.tsx
@@ -50,7 +50,10 @@ export default function FriendsPage() {
         <ul className="space-y-2">
           {friends.map((u) => (
             <li key={u.id} className="flex items-center justify-between rounded-lg border p-3">
-              <div className="flex items-center gap-3">
+              <Link
+                href={u.username ? `/u/${u.username}` : "#"}
+                className="flex items-center gap-3 hover:opacity-80"
+              >
                 <Avatar className="h-9 w-9">
                   <AvatarImage src={u.image ?? undefined} />
                   <AvatarFallback>{initials(u.name)}</AvatarFallback>
@@ -61,7 +64,7 @@ export default function FriendsPage() {
                     <p className="text-xs text-muted-foreground">@{u.username}</p>
                   )}
                 </div>
-              </div>
+              </Link>
               <Button
                 size="sm"
                 variant="ghost"

--- a/src/app/(app)/people/page.tsx
+++ b/src/app/(app)/people/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import { api } from "@/trpc/react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -56,7 +57,7 @@ export default function PeoplePage() {
           <ul className="space-y-2">
             {friendData!.incoming.map((u) => (
               <li key={u.id} className="flex items-center justify-between rounded-lg border p-3">
-                <div className="flex items-center gap-3">
+                <Link href={u.username ? `/u/${u.username}` : "#"} className="flex items-center gap-3 hover:opacity-80">
                   <Avatar className="h-9 w-9">
                     <AvatarImage src={u.image ?? undefined} />
                     <AvatarFallback>{initials(u.name)}</AvatarFallback>
@@ -65,7 +66,7 @@ export default function PeoplePage() {
                     <p className="text-sm font-medium">{u.name}</p>
                     {u.username && <p className="text-xs text-muted-foreground">@{u.username}</p>}
                   </div>
-                </div>
+                </Link>
                 <div className="flex gap-2">
                   <Button
                     size="sm"
@@ -116,7 +117,7 @@ export default function PeoplePage() {
               const isPending = outgoingIds.has(u.id);
               return (
                 <li key={u.id} className="flex items-center justify-between rounded-lg border p-3">
-                  <div className="flex items-center gap-3">
+                  <Link href={u.username ? `/u/${u.username}` : "#"} className="flex items-center gap-3 hover:opacity-80">
                     <Avatar className="h-9 w-9">
                       <AvatarImage src={u.image ?? undefined} />
                       <AvatarFallback>{initials(u.name)}</AvatarFallback>
@@ -127,7 +128,7 @@ export default function PeoplePage() {
                         <p className="text-xs text-muted-foreground">@{u.username}</p>
                       )}
                     </div>
-                  </div>
+                  </Link>
                   {isFriend ? (
                     <span className="text-xs text-muted-foreground">Friends</span>
                   ) : isPending ? (

--- a/src/app/(app)/u/[username]/add-friend-button.tsx
+++ b/src/app/(app)/u/[username]/add-friend-button.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { api } from "@/trpc/react";
+import { Button } from "@/components/ui/button";
+
+export function AddFriendButton({ targetId }: { targetId: string }) {
+  const { data, refetch } = api.friends.list.useQuery();
+
+  const send = api.friends.sendRequest.useMutation({ onSuccess: () => void refetch() });
+  const cancel = api.friends.cancelRequest.useMutation({ onSuccess: () => void refetch() });
+  const respond = api.friends.respondToRequest.useMutation({ onSuccess: () => void refetch() });
+  const remove = api.friends.remove.useMutation({ onSuccess: () => void refetch() });
+
+  if (!data) return null;
+
+  const isFriend = data.friends.some((u) => u.id === targetId);
+  const isOutgoing = data.outgoing.some((u) => u.id === targetId);
+  const isIncoming = data.incoming.some((u) => u.id === targetId);
+
+  if (isFriend) {
+    return (
+      <Button
+        variant="outline"
+        className="text-destructive hover:text-destructive"
+        onClick={() => remove.mutate({ friendId: targetId })}
+        disabled={remove.isPending}
+      >
+        Remove friend
+      </Button>
+    );
+  }
+
+  if (isOutgoing) {
+    return (
+      <Button
+        variant="outline"
+        onClick={() => cancel.mutate({ addresseeId: targetId })}
+        disabled={cancel.isPending}
+      >
+        Cancel request
+      </Button>
+    );
+  }
+
+  if (isIncoming) {
+    return (
+      <div className="flex gap-2">
+        <Button
+          onClick={() => respond.mutate({ requesterId: targetId, accept: true })}
+          disabled={respond.isPending}
+        >
+          Accept request
+        </Button>
+        <Button
+          variant="outline"
+          onClick={() => respond.mutate({ requesterId: targetId, accept: false })}
+          disabled={respond.isPending}
+        >
+          Decline
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <Button
+      onClick={() => send.mutate({ addresseeId: targetId })}
+      disabled={send.isPending}
+    >
+      Add friend
+    </Button>
+  );
+}

--- a/src/app/(app)/u/[username]/page.tsx
+++ b/src/app/(app)/u/[username]/page.tsx
@@ -1,0 +1,61 @@
+import { notFound } from "next/navigation";
+import { TRPCError } from "@trpc/server";
+import { trpc } from "@/trpc/server";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { AddFriendButton } from "./add-friend-button";
+
+function initials(name: string) {
+  return name
+    .split(" ")
+    .map((w) => w[0])
+    .join("")
+    .toUpperCase()
+    .slice(0, 2);
+}
+
+export default async function UserProfilePage({
+  params,
+}: {
+  params: Promise<{ username: string }>;
+}) {
+  const { username } = await params;
+
+  let profile;
+  try {
+    profile = await trpc.friends.getProfile({ username });
+  } catch (err) {
+    if (err instanceof TRPCError && err.code === "NOT_FOUND") notFound();
+    throw err;
+  }
+
+  const isPrivate = profile.profileVisibility === "private";
+
+  return (
+    <div className="mx-auto max-w-lg space-y-6">
+      <div className="flex items-center gap-5">
+        <Avatar className="h-20 w-20">
+          {profile.image && <AvatarImage src={profile.image} />}
+          <AvatarFallback className="text-xl">{initials(profile.name)}</AvatarFallback>
+        </Avatar>
+        <div className="space-y-1">
+          <h1 className="text-2xl font-bold">{profile.name}</h1>
+          {profile.username && (
+            <p className="text-muted-foreground">@{profile.username}</p>
+          )}
+          {isPrivate && (
+            <p className="text-sm text-muted-foreground">This profile is private.</p>
+          )}
+        </div>
+      </div>
+
+      {!isPrivate && (
+        <>
+          {profile.bio && (
+            <p className="text-sm text-muted-foreground whitespace-pre-wrap">{profile.bio}</p>
+          )}
+          <AddFriendButton targetId={profile.id} />
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/server/trpc/routers/friends.ts
+++ b/src/server/trpc/routers/friends.ts
@@ -199,6 +199,31 @@ export const friendsRouter = createTRPCRouter({
         );
     }),
 
+  // Fetch a public profile by username (CAMP-021)
+  // Open profiles return full data; private profiles return name only.
+  getProfile: publicProcedure
+    .input(z.object({ username: z.string() }))
+    .query(async ({ input }) => {
+      const found = await db.query.user.findFirst({
+        where: eq(user.username, input.username),
+        columns: {
+          id: true,
+          name: true,
+          username: true,
+          image: true,
+          bio: true,
+          profileVisibility: true,
+        },
+      });
+      if (!found) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "User not found." });
+      }
+      if (found.profileVisibility === "private") {
+        return { id: found.id, name: found.name, username: found.username, image: null, bio: null, profileVisibility: "private" as const };
+      }
+      return found;
+    }),
+
   // Resolve an invite token to a public profile — no auth required (CAMP-023)
   resolveInviteToken: publicProcedure
     .input(z.object({ token: z.string() }))


### PR DESCRIPTION
## Summary

- Adds `GET /u/[username]` profile pages — open profiles show avatar, name, bio and a contextual friend button; private profiles show a minimal view
- Adds `friends.getProfile` public tRPC procedure (visibility-aware)
- Usernames in `/friends` and `/people` are now clickable links to profile pages
- Friend button handles all states: add, cancel pending, accept/decline incoming, remove friend

## Test plan

- [ ] Visit `/u/<username>` for an open-profile user — avatar, name, bio visible, Add friend button shown
- [ ] Visit `/u/<username>` for a private-profile user — only name shown, no bio or friend action
- [ ] Visit `/u/<nonexistent>` — 404 page
- [ ] Add friend, cancel, accept, decline, remove all work from profile page
- [ ] Clicking a friend's name on `/friends` navigates to their profile
- [ ] Clicking a search result name on `/people` navigates to their profile
- [ ] User without a username set — links fall back to `#` (no broken URL)

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)