### PR TITLE
feat(CAMP-028/029): block user from feed + unblock from settings

### DIFF
--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -2,10 +2,61 @@
 
 import { useState, useEffect } from "react";
 import { api } from "@/trpc/react";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import type { NotificationPrefs } from "@/server/db/schema";
+
+// ── Blocked users section ─────────────────────────────────────────────────────
+
+function BlockedUsersSection() {
+  const { data: blocked, refetch } = api.friends.listBlocked.useQuery();
+  const unblock = api.friends.unblock.useMutation({ onSuccess: () => void refetch() });
+
+  if (!blocked?.length) {
+    return (
+      <section className="space-y-4">
+        <h2 className="text-base font-semibold border-b pb-2">Blocked users</h2>
+        <p className="text-sm text-muted-foreground">You haven&apos;t blocked anyone.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="space-y-4">
+      <h2 className="text-base font-semibold border-b pb-2">Blocked users</h2>
+      <ul className="space-y-2">
+        {blocked.map((u) => (
+          <li key={u.id} className="flex items-center justify-between rounded-lg border p-3">
+            <div className="flex items-center gap-3">
+              <Avatar className="h-9 w-9">
+                <AvatarImage src={u.image ?? undefined} />
+                <AvatarFallback>{initials(u.name)}</AvatarFallback>
+              </Avatar>
+              <div>
+                <p className="text-sm font-medium">{u.name}</p>
+                {u.username && <p className="text-xs text-muted-foreground">@{u.username}</p>}
+              </div>
+            </div>
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={unblock.isPending}
+              onClick={() => unblock.mutate({ targetId: u.id })}
+            >
+              Unblock
+            </Button>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function initials(name: string) {
+  return name.split(" ").map((w) => w[0]).join("").toUpperCase().slice(0, 2);
+}
 
 // ── Toggle row ────────────────────────────────────────────────────────────────
 
@@ -316,6 +367,9 @@ export default function SettingsPage() {
           </div>
         </div>
       </section>
+
+      {/* ── Blocked users ─────────────────────────────────────────────────────── */}
+      <BlockedUsersSection />
     </div>
   );
 }

--- a/src/components/feed/post-card.tsx
+++ b/src/components/feed/post-card.tsx
@@ -89,6 +89,7 @@ export function PostCard({
 
   const toggleLike = api.feed.toggleLike.useMutation({ onSuccess: onRefresh });
   const deletePost = api.feed.delete.useMutation({ onSuccess: onRefresh });
+  const blockUser = api.friends.block.useMutation({ onSuccess: onRefresh });
   const addComment = api.feed.comment.useMutation({
     onSuccess: () => {
       setCommentBody("");
@@ -120,12 +121,24 @@ export function PostCard({
             </p>
           </div>
         </div>
-        {post.author.id === currentUserId && (
+        {post.author.id === currentUserId ? (
           <button
             className="text-xs text-muted-foreground hover:text-destructive"
             onClick={() => deletePost.mutate({ id: post.id })}
           >
             Delete
+          </button>
+        ) : (
+          <button
+            className="text-xs text-muted-foreground hover:text-destructive"
+            onClick={() => {
+              if (window.confirm(`Block ${post.author.name}? Their posts will be hidden from your feed.`)) {
+                blockUser.mutate({ targetId: post.author.id });
+              }
+            }}
+            disabled={blockUser.isPending}
+          >
+            Block
           </button>
         )}
       </div>

--- a/src/server/trpc/routers/friends.ts
+++ b/src/server/trpc/routers/friends.ts
@@ -184,6 +184,20 @@ export const friendsRouter = createTRPCRouter({
       });
     }),
 
+  // List users blocked by the current user (CAMP-028/029)
+  listBlocked: protectedProcedure.query(async ({ ctx }) => {
+    const rows = await db.query.friendships.findMany({
+      where: and(
+        eq(friendships.requesterId, ctx.user.id),
+        eq(friendships.status, "blocked")
+      ),
+      with: {
+        addressee: { columns: { id: true, name: true, username: true, image: true } },
+      },
+    });
+    return rows.map((r) => r.addressee);
+  }),
+
   // Unblock (CAMP-029)
   unblock: protectedProcedure
     .input(z.object({ targetId: z.string() }))


### PR DESCRIPTION
## Summary

- **CAMP-028**: Adds a "Block" button on other users' posts in the feed. Clicking prompts a confirmation, then calls `friends.block` and refreshes the feed — blocked users' posts disappear immediately (already filtered server-side).
- **CAMP-029**: Adds a "Blocked users" section at the bottom of Settings, listing all blocked users with an Unblock button per row.
- Adds `friends.listBlocked` tRPC procedure.

> Note: The feed hard-filters blocked users at the DB level, so mid-feed placeholders would require a feed architecture change. Settings-based unblock is the minimal correct implementation — consistent with how most social apps handle this.

## Test plan

- [ ] Block a user from their post in the feed — confirmation dialog appears, then their posts disappear on refresh
- [ ] Blocking a user you're already friends with works (removes friendship row, inserts blocked row)
- [ ] Settings > Blocked users shows the blocked user with name/username/avatar
- [ ] Unblock from settings removes them from the list and restores their posts in the feed
- [ ] Blocking yourself is not possible (guarded server-side by the existing `friends.block` procedure)

Closes #21
Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)