### PR TITLE
feat(CAMP-086): post editing with edited timestamp

### DIFF
--- a/src/components/feed/post-card.tsx
+++ b/src/components/feed/post-card.tsx
@@ -176,7 +176,9 @@ export function PostCard({
   const postTextareaRef = useRef<HTMLTextAreaElement>(null);
 
   const toggleLike = api.feed.toggleLike.useMutation({ onSuccess: onRefresh });
-  const deletePost = api.feed.delete.useMutation({ onSuccess: onRefresh });
+  const deletePost = api.feed.delete.useMutation({
+    onSuccess: () => { setEditingPost(false); onRefresh(); },
+  });
   const editPostMutation = api.feed.editPost.useMutation({
     onSuccess: () => { setEditingPost(false); onRefresh(); },
   });
@@ -231,19 +233,21 @@ export function PostCard({
         {isOwn ? (
           <div className="flex gap-2">
             {!editingPost && (
-              <button
-                className="text-xs text-muted-foreground hover:text-foreground"
-                onClick={() => setEditingPost(true)}
-              >
-                Edit
-              </button>
+              <>
+                <button
+                  className="text-xs text-muted-foreground hover:text-foreground"
+                  onClick={() => setEditingPost(true)}
+                >
+                  Edit
+                </button>
+                <button
+                  className="text-xs text-muted-foreground hover:text-destructive"
+                  onClick={() => deletePost.mutate({ id: post.id })}
+                >
+                  Delete
+                </button>
+              </>
             )}
-            <button
-              className="text-xs text-muted-foreground hover:text-destructive"
-              onClick={() => deletePost.mutate({ id: post.id })}
-            >
-              Delete
-            </button>
           </div>
         ) : (
           <button

--- a/src/server/trpc/routers/feed.ts
+++ b/src/server/trpc/routers/feed.ts
@@ -112,7 +112,7 @@ export const feedRouter = createTRPCRouter({
   // Edit own post body (CAMP-086)
   // Single UPDATE with ownership + soft-delete check to avoid TOCTOU.
   editPost: protectedProcedure
-    .input(z.object({ id: z.string(), body: z.string().min(1).max(1000) }))
+    .input(z.object({ id: z.string(), body: z.string().trim().min(1).max(1000) }))
     .mutation(async ({ ctx, input }) => {
       const [updated] = await db
         .update(posts)


### PR DESCRIPTION
## Summary

Adds inline post body editing. Authors see an Edit button alongside Delete on their own posts. Clicking opens an inline textarea pre-filled with the current body. Saving commits the edit (sets `editedAt`); Escape or Cancel reverts. The `(edited)` label was already rendered in the header — it now shows correctly once a post is edited.

Scope is body-only. Image editing is deferred to CAMP-082 (image uploads not yet implemented).

## Changes

### `src/server/trpc/routers/feed.ts`
- Added `editPost` procedure: single `UPDATE ... WHERE id=? AND authorId=? AND deletedAt IS NULL RETURNING id`. Throws `NOT_FOUND` if 0 rows matched. Sets `body` and `editedAt` atomically — no TOCTOU between ownership check and write.

### `src/components/feed/post-card.tsx`
- `PostCard` gains `editingPost` state, `editPostBody` state, `postTextareaRef`, and `editPostMutation`.
- `useEffect` auto-focuses textarea on edit open.
- `useEffect` syncs `editPostBody` when `post.body` changes from a refetch while not editing.
- `cancelPostEdit()` helper (same pattern as `cancelEdit` in `CommentRow`).
- Own-post header actions: Edit + Delete shown side by side; Edit button hidden while editing to avoid conflicts.
- Body area: toggles between read-only `<p>` and inline edit form (Textarea + Save/Cancel).

## Security model

- `editPost` is behind `protectedProcedure` (`src/server/trpc/trpc.ts`). Ownership enforced in the `WHERE` clause (`authorId = ctx.user.id`) — a user cannot edit another user's post. Soft-deleted posts are also excluded (`deletedAt IS NULL`). No separate check + update step; single atomic query.

## Known tradeoffs

- Body-only editing. Image editing deferred to CAMP-082.
- No edit history — only the latest body is stored, consistent with comment editing (CAMP-088).