### PR TITLE
review: verify URL lookbehind fix from #161 (merged without re-review)

### DIFF
--- a/src/server/trpc/routers/feed.ts
+++ b/src/server/trpc/routers/feed.ts
@@ -171,7 +171,9 @@ export const feedRouter = createTRPCRouter({
       // Only one URL per post (one embed per product spec).
       // Trailing punctuation commonly appended in prose (., ), ;, etc.) is stripped.
       // Fire-and-forget: a Redis/queue failure must not fail the post creation itself.
-      const urlMatch = /https?:\/\/[^\s<>"]+/i.exec(input.body);
+      // (?<![='"]) negative lookbehind: skip URLs that appear inside HTML attribute
+      // values (e.g. src="https://..." in pasted iframe code).
+      const urlMatch = /(?<![='"])https?:\/\/[^\s<>"]+/i.exec(input.body);
       if (urlMatch) {
         const cleanUrl = urlMatch[0].replace(/[).,;:!?\]]+$/, "");
         enqueueOgFetch(id, cleanUrl).catch((err: unknown) => {


### PR DESCRIPTION
## Context

PR #161 was merged without waiting for a re-review after a post-NITPICK fix. This PR presents the identical diff for proper review.

The original review on #161 gave **APPROVE** but flagged:

> **[NITPICK]** `[='"']` has a duplicate `'` — simplify to `[='"]`

A fix was pushed (`b71fb88`) and the PR was merged immediately without polling for a second review cycle. This PR exists solely to give the review bot visibility on the final committed state.

## What the diff shows

Single-line change to `src/server/trpc/routers/feed.ts`:

```diff
- const urlMatch = /https?:\/\/[^\s<>"]+/i.exec(input.body);
+ const urlMatch = /(?<![='"])https?:\/\/[^\s<>"]+/i.exec(input.body);
```

**Negative lookbehind `(?<![='"])`** — skips URLs immediately preceded by `=`, `'`, or `"` (i.e. inside an HTML attribute value such as a pasted `<iframe src="...">` snippet). A URL in prose is preceded by whitespace and is still matched normally.

The character class `[='"]` contains exactly three characters: `=`, `'`, `"`. The duplicate `'` from the original commit has been removed.

## Security model

- `feed.create` is behind `protectedProcedure`.
- This is input-validation only — no DB writes or auth changes in this diff.
- The lookbehind is fixed-width (1 char) — no backtracking risk.

## Known tradeoffs

None. This is a narrowing of the match.