### PR TITLE
feat(CAMP-094,CAMP-095): event-scoped posts + group admin pin

### DIFF
--- a/src/app/(app)/events/[id]/page.tsx
+++ b/src/app/(app)/events/[id]/page.tsx
@@ -208,8 +208,7 @@ function CreatePollDialog({ eventId, groupId, onCreated }: { eventId: string; gr
 
 // ── Event discussion ──────────────────────────────────────────────────────────
 
-function EventDiscussion({ eventId, groupId, isGroupAdmin }: { eventId: string; groupId: string; isGroupAdmin: boolean }) {
-  const { data: me } = api.user.me.useQuery();
+function EventDiscussion({ eventId, groupId, currentUserId, isGroupAdmin }: { eventId: string; groupId: string; currentUserId: string; isGroupAdmin: boolean }) {
   const { data: eventPosts, refetch } = api.feed.listForEvent.useQuery({ eventId });
 
   function refresh() { void refetch(); }
@@ -225,7 +224,7 @@ function EventDiscussion({ eventId, groupId, isGroupAdmin }: { eventId: string; 
         <PostCard
           key={post.id}
           post={post}
-          currentUserId={me?.id ?? ""}
+          currentUserId={currentUserId}
           isGroupAdmin={isGroupAdmin}
           onRefresh={refresh}
         />
@@ -364,7 +363,7 @@ export default function EventDetailPage({ params }: { params: Promise<{ id: stri
       </div>
 
       {/* Discussion */}
-      <EventDiscussion eventId={id} groupId={event.groupId} isGroupAdmin={isGroupAdmin} />
+      <EventDiscussion eventId={id} groupId={event.groupId} currentUserId={myUserId} isGroupAdmin={isGroupAdmin} />
 
       {/* Status controls (for event creator) */}
       {isEventCreator && (event.status === "open" || event.status === "draft") && (

--- a/src/components/feed/post-card.tsx
+++ b/src/components/feed/post-card.tsx
@@ -7,6 +7,7 @@ import { api } from "@/trpc/react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
 
 function initials(name: string) {
   return name.split(" ").map((w) => w[0]).join("").toUpperCase().slice(0, 2);
@@ -220,7 +221,7 @@ export function PostCard({
   const imageUrls = (post.imageUrls ?? []).filter((u): u is string => u !== null);
 
   return (
-    <article className={`space-y-3 rounded-lg border p-4 ${post.pinnedAt ? "border-primary/40 bg-primary/5" : ""}`}>
+    <article className={cn("space-y-3 rounded-lg border p-4", post.pinnedAt && "border-primary/40 bg-primary/5")}>
       {/* Pinned indicator */}
       {post.pinnedAt && (
         <p className="text-xs font-medium text-primary">📌 Pinned</p>

--- a/src/server/trpc/routers/feed.ts
+++ b/src/server/trpc/routers/feed.ts
@@ -125,6 +125,8 @@ export const feedRouter = createTRPCRouter({
     }),
 
   // Create a post (CAMP-080, CAMP-094)
+  // groupId and eventId are mutually exclusive: eventId resolves its own groupId server-side,
+  // so supplying both would create an ambiguity. Enforce this at the schema level.
   create: protectedProcedure
     .input(
       z.object({
@@ -132,6 +134,7 @@ export const feedRouter = createTRPCRouter({
         groupId: z.string().optional(),
         // eventId: scopes the post to a specific event's discussion thread (CAMP-094).
         // The event must belong to a group the caller is a member of.
+        // Mutually exclusive with groupId — eventId resolves its own groupId server-side.
         eventId: z.string().optional(),
         // imageKeys: raw MinIO keys returned by /api/upload/post-image, one per image slot.
         // Pattern: posts/{userId}/{uploadId}/{cuid}-raw
@@ -141,7 +144,10 @@ export const feedRouter = createTRPCRouter({
           .array(z.string().regex(/^posts\/[A-Za-z0-9]+\/[A-Za-z0-9]{10,}\/[a-z0-9]+-raw$/))
           .max(4)
           .optional(),
-      })
+      }).refine(
+        (v) => !(v.groupId && v.eventId),
+        { message: "groupId and eventId are mutually exclusive" }
+      )
     )
     .mutation(async ({ ctx, input }) => {
       // Verify all imageKeys belong to the calling user (prefix = posts/{userId}/).
@@ -154,9 +160,10 @@ export const feedRouter = createTRPCRouter({
         }
       }
 
-      // Authz for event-scoped posts: caller must be a member of the event's group.
-      // groupId is inferred from the event rather than supplied separately.
-      let resolvedGroupId = input.groupId ?? null;
+      // Authz: verify the caller is a member of the target group.
+      // For event-scoped posts: groupId is inferred from the event.
+      // For group-scoped posts: groupId is supplied directly — membership still checked.
+      let resolvedGroupId: string | null = null;
       if (input.eventId) {
         const event = await db.query.events.findFirst({
           where: eq(events.id, input.eventId),
@@ -172,6 +179,16 @@ export const feedRouter = createTRPCRouter({
         });
         if (!membership) throw new TRPCError({ code: "FORBIDDEN", message: "Not a member of this group." });
         resolvedGroupId = event.groupId;
+      } else if (input.groupId) {
+        const membership = await db.query.groupMemberships.findFirst({
+          where: and(
+            eq(groupMemberships.groupId, input.groupId),
+            eq(groupMemberships.userId, ctx.user.id)
+          ),
+          columns: { groupId: true },
+        });
+        if (!membership) throw new TRPCError({ code: "FORBIDDEN", message: "Not a member of this group." });
+        resolvedGroupId = input.groupId;
       }
 
       await assertRateLimit(`rl:feed:create:${ctx.user.id}`, 10, 60);


### PR DESCRIPTION
## Summary

- **CAMP-094**: Posts can now be scoped to a specific event. The event detail page has a Discussion section where group members can post and comment, keeping conversation tied to the planning context.
- **CAMP-095**: Group admins (owner/admin role) can pin posts to the top of a group feed or event discussion. Pinned posts are visually highlighted and floated first.

## Changes

### Schema
- `posts.event_id` — nullable FK to `events(id)`, cascade delete. Migration applied (`drizzle/0005_bumpy_nightcrawler.sql`, gitignored per project convention).
- `postsRelations` — new `event` relation.

### tRPC: `feed` router
- **`create`**: new optional `eventId` input. Authz: caller must be a member of the event's group; `groupId` is resolved from the event (not supplied separately by the client).
- **`list`**: now includes `event { id, title }` in the `with` clause so feed cards can show event context.
- **`listForEvent`** (new): returns all non-deleted posts scoped to an event, pinned first then newest. Authz: group membership required.
- **`pinPost`** (new): toggles `pinnedAt` on a group post. Authz: caller must be `owner` or `admin` in the post's group. Returns `{ pinned: boolean }`.

### UI
- `PostComposer`: accepts optional `eventId` prop, passed through to `feed.create`.
- `PostCard`:
  - `PostData` type gains `pinnedAt` and `event` fields.
  - Event title shown in post subheading alongside group name.
  - Pinned posts get a subtle `border-primary/40 bg-primary/5` highlight and a "📌 Pinned" label.
  - Pin/Unpin button shown to group admins (new `isGroupAdmin` prop) on all group posts, own and others'.
- `EventDetailPage`: new `EventDiscussion` component below polls — PostComposer + PostCard list via `feed.listForEvent`. Group admin status resolved via `groups.get`.

## Security model

- `feed.create` with `eventId`: `protectedProcedure` (authenticated) + explicit group membership check before insert. `groupId` is server-resolved from the event — client cannot set an arbitrary `groupId`.
- `feed.listForEvent`: `protectedProcedure` + group membership check on the event's group.
- `feed.pinPost`: `protectedProcedure` + group membership with role check (`owner` or `admin`). The post is fetched server-side; client only supplies `postId`.
- `isGroupAdmin` in the UI is cosmetic (controls visibility of pin button). The real authz gate is in `feed.pinPost` on the server.

## Schema migration

The migration adds one nullable column with a FK — safe for rolling deploys, no backfill needed. Applied to the running DB before this PR was pushed.

## Known tradeoffs

- `listForEvent` is unbounded (no cursor pagination). At MVP scale (small friend groups, limited events) this is fine.
- Event-scoped posts also appear in the main group feed — intentional, so event discussion surfaces in the group timeline.

## Test plan

- [ ] Post to an event discussion → appears in event detail Discussion section
- [ ] Post to an event discussion → also visible in the main/group feed (with event title in subheading)
- [ ] Non-member cannot post to event (403 from `feed.create`)
- [ ] Group admin sees Pin/Unpin button on group posts; non-admin does not
- [ ] Pin a post → it floats to top with highlight + Pinned label; Unpin restores normal order
- [ ] Non-admin calling `feed.pinPost` directly returns FORBIDDEN
- [ ] Pinning a post not in a group returns BAD_REQUEST