### PR TITLE
chore: ignore .claude/*.lock files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ next-env.d.ts
 
 # Claude Code local settings
 .claude/settings.local.json
+.claude/*.lock


### PR DESCRIPTION
## Summary

Adds `.claude/*.lock` to `.gitignore` so Claude Code's scheduled task lock files don't appear as untracked files in `git status`.

## Security model

No code changes. Gitignore-only.

## Known tradeoffs

None.