### PR TITLE
chore(worker): lazy-init accountQueue + exhaustive switch default (TD-025, TD-026)

### DIFF
--- a/src/server/jobs/account-jobs.ts
+++ b/src/server/jobs/account-jobs.ts
@@ -14,18 +14,28 @@ export type SweepUnscrubbedPayload = {
 
 export type AccountJobPayload = ScrubAccountPayload | SweepUnscrubbedPayload;
 
-export const accountQueue = new Queue<AccountJobPayload>("account", {
-  connection: bullmqConnection,
-  defaultJobOptions: {
-    attempts: 5,
-    backoff: { type: "exponential", delay: 10_000 },
-    removeOnComplete: 100,
-    removeOnFail: 200,
-  },
-});
+// Lazy singleton — created on first call so that importing this module in a
+// Next.js server context (e.g. via the tRPC user router) does not open a
+// Redis connection on every cold start, only when a job is actually enqueued.
+let _accountQueue: Queue<AccountJobPayload> | undefined;
+
+export function getAccountQueue(): Queue<AccountJobPayload> {
+  if (!_accountQueue) {
+    _accountQueue = new Queue<AccountJobPayload>("account", {
+      connection: bullmqConnection,
+      defaultJobOptions: {
+        attempts: 5,
+        backoff: { type: "exponential", delay: 10_000 },
+        removeOnComplete: 100,
+        removeOnFail: 200,
+      },
+    });
+  }
+  return _accountQueue;
+}
 
 export function enqueueScrubAccount(userId: string) {
-  return accountQueue.add(
+  return getAccountQueue().add(
     "scrub_account",
     { type: "scrub_account", userId },
     // Small delay so the HTTP response completes before the job fires

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -4,7 +4,7 @@ import { processEmailJob } from "./processors/email";
 import { processAccountJob } from "./processors/account";
 import { processImageJob } from "./processors/image";
 import { processOgFetchJob } from "./processors/og-fetch";
-import { accountQueue } from "@/server/jobs/account-jobs";
+import { getAccountQueue } from "@/server/jobs/account-jobs";
 import { imageQueue } from "@/server/jobs/image-jobs";
 import type { EmailJobPayload } from "@/server/jobs/email-jobs";
 import type { AccountJobPayload } from "@/server/jobs/account-jobs";
@@ -39,7 +39,7 @@ new Worker<AccountJobPayload>(
 // Hourly sweeper: finds deleted accounts where the scrub job was lost (e.g. Redis
 // was down during deleteAccount) and re-enqueues them. This is the fallback
 // recovery mechanism for the fire-and-forget enqueue in the tRPC mutation.
-accountQueue.add(
+getAccountQueue().add(
   "sweep_unscrubbed",
   { type: "sweep_unscrubbed" },
   { repeat: { every: 60 * 60 * 1000 }, jobId: "sweep_unscrubbed" },

--- a/src/worker/processors/account.ts
+++ b/src/worker/processors/account.ts
@@ -2,7 +2,7 @@ import type { Job } from "bullmq";
 import { and, eq, isNotNull } from "drizzle-orm";
 import { db } from "@/server/db";
 import { user, session, account } from "@/server/db/schema";
-import { accountQueue } from "@/server/jobs/account-jobs";
+import { getAccountQueue } from "@/server/jobs/account-jobs";
 import type { AccountJobPayload } from "@/server/jobs/account-jobs";
 
 export async function processAccountJob(job: Job<AccountJobPayload>) {
@@ -79,7 +79,7 @@ export async function processAccountJob(job: Job<AccountJobPayload>) {
         unscrubbed.map((u) =>
           // Deterministic jobId deduplicates: if a scrub job is already queued
           // for this user, BullMQ will not add a second one.
-          accountQueue.add(
+          getAccountQueue().add(
             "scrub_account",
             { type: "scrub_account", userId: u.id },
             { jobId: `scrub-${u.id}` },
@@ -91,7 +91,8 @@ export async function processAccountJob(job: Job<AccountJobPayload>) {
     }
 
     default: {
-      console.warn("Unknown account job type:", (data as { type: string }).type);
+      const _exhaustive: never = data;
+      console.warn("Unknown account job type:", (_exhaustive as { type: string }).type);
     }
   }
 }


### PR DESCRIPTION
## Summary

Fixes two related tech-debt items in the account job infrastructure introduced in PR #132.

**TD-025 — Lazy-init accountQueue**

`accountQueue` was previously a module-scope `new Queue(...)` in `src/server/jobs/account-jobs.ts`. Because the tRPC user router imports `enqueueScrubAccount` from this module, every Next.js server cold start (including any invocation that never calls `deleteAccount`) opened a BullMQ Redis connection eagerly.

Changed to a `getAccountQueue()` lazy singleton: the `Queue` is created only on first call. Callers updated:
- `account-jobs.ts`: `enqueueScrubAccount` calls `getAccountQueue()`
- `src/worker/index.ts`: calls `getAccountQueue()` to register the `sweep_unscrubbed` repeatable job at startup
- `src/worker/processors/account.ts`: `sweep_unscrubbed` handler calls `getAccountQueue()` to re-enqueue scrub jobs

The worker process still creates the queue at startup (it's called at module scope in `index.ts`), so runtime behaviour is identical. The benefit is on the Next.js side: a request that never enqueues an account job no longer pays the connection cost.

**TD-026 — Exhaustive switch default**

The `default` branch in `processAccountJob` used an unsafe cast:
```ts
console.warn("Unknown account job type:", (data as { type: string }).type);
```
This hid any unhandled `AccountJobPayload` union member at compile time. Replaced with:
```ts
const _exhaustive: never = data;
console.warn("Unknown account job type:", (_exhaustive as { type: string }).type);
```
TypeScript now produces a compile error if `AccountJobPayload` gains a new member without a corresponding `case`.

## Security model

No auth/authz changes. The account job processor runs in the worker process (not user-facing). The queue is still named `"account"` with the same BullMQ connection settings — only the creation timing changed.

## Known tradeoffs

- Module-level singleton means the queue instance is shared across the lifetime of the process. This is the same as before; the change only defers creation. No test isolation concern at MVP scale (no integration tests for this path yet — tracked in #133).

## Files changed

- `src/server/jobs/account-jobs.ts` — lazy `getAccountQueue()` factory replacing module-scope export
- `src/worker/index.ts` — `accountQueue` → `getAccountQueue()`
- `src/worker/processors/account.ts` — same import swap + `never` exhaustiveness check

🤖 Generated with [Claude Code](https://claude.com/claude-code)