### PR TITLE
chore(groups,feed): group name server trim + CommentRow (edited) label fix (#155, #148)

### DIFF
--- a/src/app/(app)/groups/[id]/page.tsx
+++ b/src/app/(app)/groups/[id]/page.tsx
@@ -83,6 +83,7 @@ function GroupSettings({ group, onSaved }: { group: GroupData; onSaved: () => vo
           <Input
             value={currentName}
             onChange={(e) => setName(e.target.value)}
+            onBlur={(e) => setName(e.target.value.trim())}
             maxLength={100}
           />
         </div>

--- a/src/components/feed/post-card.tsx
+++ b/src/components/feed/post-card.tsx
@@ -136,8 +136,10 @@ function CommentRow({
             title={new Date(comment.createdAt).toLocaleString()}
           >
             {formatDistanceToNow(new Date(comment.createdAt), { addSuffix: true })}
-            {comment.editedAt && <span className="ml-1">(edited)</span>}
           </span>
+          {comment.editedAt && (
+            <span className="text-xs text-muted-foreground">(edited)</span>
+          )}
           <button
             className={`text-xs ${hasLiked ? "text-primary font-medium" : "text-muted-foreground hover:text-foreground"}`}
             onClick={() => toggleLike.mutate({ commentId: comment.id })}

--- a/src/server/trpc/routers/groups.ts
+++ b/src/server/trpc/routers/groups.ts
@@ -92,7 +92,7 @@ export const groupsRouter = createTRPCRouter({
     .input(
       z.object({
         id: z.string(),
-        name: z.string().min(1).max(100).optional(),
+        name: z.string().trim().min(1).max(100).optional(),
         description: z.string().max(500).optional(),
         discordInviteUrl,
       })


### PR DESCRIPTION
## Summary

Two small polish fixes surfaced in earlier PR reviews.

**#155 — Group name whitespace validation**

The `update` procedure in `src/server/trpc/routers/groups.ts` had `z.string().min(1)` on `name`. A whitespace-only value like `"   "` passes `min(1)` (length ≥ 1) but is not a valid group name. Added `.trim()` before `.min(1)` so Zod rejects it server-side.

The client also now trims the name input `onBlur` (in `GroupSettings` in `src/app/(app)/groups/[id]/page.tsx`), so the displayed value matches what will be submitted after the user tabs away. The Save button was already guarded by `!currentName.trim()`, so no bad data could actually be saved — this is defence-in-depth and UX polish.

**#148 — CommentRow `(edited)` label as sibling span**

In `src/components/feed/post-card.tsx`, the `(edited)` label in `CommentRow` was nested inside the timestamp `<span>`, making it hard to target independently for styling or tests. Moved to a sibling `<span className="text-xs text-muted-foreground">` element within the same flex row.

The post-level `(edited)` label (also in `post-card.tsx`) is embedded in a mixed-text `<p>` alongside `@username ·`, relative time, `· Group name` etc. — that context is different and left unchanged.

## Security model

No auth/authz changes. The `update` procedure is already guarded by `protectedProcedure` + an explicit admin/owner membership check (see `src/server/trpc/routers/groups.ts:101-109`). This change only tightens the input validation.

## Known tradeoffs

None. Both changes are strictly narrowing: the server rejects slightly more input (whitespace-only names), and the UI label is more easily targetable.

## Files changed

- `src/server/trpc/routers/groups.ts` — `.trim().min(1)` on `name`
- `src/app/(app)/groups/[id]/page.tsx` — `onBlur` trim on name input
- `src/components/feed/post-card.tsx` — `(edited)` span moved to sibling in `CommentRow`

🤖 Generated with [Claude Code](https://claude.com/claude-code)