### PR TITLE
feat(TD-008): optimistic updates for post like and comment

### DIFF
--- a/src/components/feed/post-card.tsx
+++ b/src/components/feed/post-card.tsx
@@ -195,7 +195,7 @@ export function PostCard({
   // Optimistic comments — extra entries appended before the server confirms.
   const [optimisticComments, setOptimisticComments] = useState<CommentData[]>([]);
 
-  const serverLiked = post.reactions.some((r) => r.userId === currentUserId);
+  const serverLiked = post.reactions.some((r) => r.userId === currentUserId && r.type === "like");
   const serverLikeCount = post.reactions.filter((r) => r.type === "like").length;
 
   // Reset optimistic overrides when server data arrives (reactions array changed).


### PR DESCRIPTION
## Summary

- **Like (post):** clicking the heart now flips the icon and count immediately via component-local state (`optimisticLiked` / `optimisticLikeCount`). If the mutation errors the optimistic state is cleared and `onRefresh` re-fetches authoritative data. On success, `onRefresh` still runs for eventual consistency.
- **Add comment:** the new comment is appended to a local `optimisticComments` list immediately in `onMutate`, so users see their comment without waiting for the server round-trip. On success the optimistic entry is replaced by the real one when `onRefresh` re-fetches.

Other mutations (delete, edit, pin, block) continue using full re-fetch only — they are infrequent enough that the round-trip isn't perceptible.

## Design choice — component-local state vs. query cache manipulation

The alternative approach is to update the tRPC React Query cache directly via `useUtils().feed.list.setInfiniteData`. That's more powerful but couples `PostCard` to a specific query key — `PostCard` is used in both `feed/page.tsx` (`feed.list` infinite query) and the event-scoped feed (`feed.listForEvent` regular query). Component-local optimistic state keeps the component query-agnostic.

## Security model

No changes to auth/authz. `toggleLike` and `comment` mutations are already behind `protectedProcedure` in `src/server/trpc/routers/feed.ts`. The optimistic update only affects local state — the server always validates the request.

## Known tradeoffs

- The optimistic comment shows `name: "You"` as a placeholder before the server confirms. It's replaced by the real author name once `onRefresh` completes (typically < 1s). An alternative would be to read the current user's name from the `user.me` query, but that adds coupling for a transient artefact.
- Double-click on like before the first mutation resolves fires two mutations. The button is not disabled during `isPending` was added for the like button (was missing before). Comment send button was already disabled during `isPending`.

## What to test

1. Click like on a post — heart flips instantly, count updates, no visible delay
2. Submit a comment — comment appears immediately in the thread, replaced by real entry after re-fetch
3. Disconnect network, click like — heart flips, then reverts after error + refetch fails gracefully

Closes #120