### PR TITLE
fix(infra): retry repeatable BullMQ job registration on startup failure

### DIFF
--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -39,7 +39,7 @@ async function registerRepeatableJob(
       return;
     } catch (err) {
       const isLast = attempt === maxAttempts;
-      const delayMs = Math.min(1000 * 2 ** (attempt - 1), 30_000); // 1s, 2s, 4s, 8s, 16s → capped at 30s
+      const delayMs = Math.min(1000 * 2 ** (attempt - 1), 30_000); // 1s, 2s, 4s, 8s, 16s (30s cap is a safeguard for callers with higher maxAttempts)
       console.error(
         `[worker] failed to register ${label} (attempt ${attempt}/${maxAttempts})${isLast ? " — giving up" : `, retrying in ${delayMs}ms`}:`,
         err,
@@ -86,6 +86,8 @@ new Worker<OgFetchJobPayload>(
   { connection: bullmqConnection }
 );
 
+console.log("Campfire workers started");
+
 // Repeatable jobs — registered with retry so a transient Redis blip at startup
 // doesn't silently disable cleanup jobs. If all retries fail the process throws,
 // which Docker Compose will restart (giving Redis time to recover).
@@ -110,7 +112,7 @@ new Worker<OgFetchJobPayload>(
       )
     ),
   ]);
-  console.log("Campfire workers started");
+  console.log("Campfire repeatable jobs registered");
 })().catch((err: unknown) => {
   console.error("[worker] fatal: could not register repeatable jobs after all retries:", err);
   process.exit(1);


### PR DESCRIPTION
## Summary

- Replaces the fire-and-forget `.catch(console.error)` pattern on repeatable job registration with a retrying helper (`registerRepeatableJob`).
- Retries up to 5 times with exponential backoff: 1s → 2s → 4s → 8s → 16s (capped at 30s).
- If all retries fail, calls `process.exit(1)` — crashing the worker process intentionally so Docker Compose (restart policy: `always`) can restart it, giving Redis time to recover.
- Both repeatable jobs (`sweep_unscrubbed`, `sweep_orphaned_uploads`) are now registered via `Promise.all` so a failure in either is visible immediately rather than silently swallowed.

## Security model

No auth/authz surface changed. This is purely a worker startup reliability fix.

## Known tradeoffs

- Workers start processing jobs immediately (the `new Worker(...)` calls happen before job registration). In the failure-then-retry window, the workers are alive but the sweep jobs haven't been scheduled yet — existing queued jobs still run normally. This is acceptable since repeatable sweeps are best-effort recovery mechanisms, not the primary job path.
- `process.exit(1)` on final failure is intentional and matches Docker Compose's restart model. An alternative would be continuing without the sweep jobs, but that silently disables PII cleanup — the crash is the safer choice.

Closes #176.

🤖 Generated with [Claude Code](https://claude.com/claude-code)