### PR TITLE
fix(feed): remove redundant groupId from PostComposer on event page

### DIFF
--- a/src/app/(app)/events/[id]/page.tsx
+++ b/src/app/(app)/events/[id]/page.tsx
@@ -208,7 +208,7 @@ function CreatePollDialog({ eventId, groupId, onCreated }: { eventId: string; gr
 
 // ── Event discussion ──────────────────────────────────────────────────────────
 
-function EventDiscussion({ eventId, groupId, currentUserId, isGroupAdmin }: { eventId: string; groupId: string; currentUserId: string; isGroupAdmin: boolean }) {
+function EventDiscussion({ eventId, currentUserId, isGroupAdmin }: { eventId: string; currentUserId: string; isGroupAdmin: boolean }) {
   const { data: eventPosts, refetch } = api.feed.listForEvent.useQuery({ eventId });
 
   function refresh() { void refetch(); }
@@ -216,7 +216,7 @@ function EventDiscussion({ eventId, groupId, currentUserId, isGroupAdmin }: { ev
   return (
     <div className="space-y-3">
       <p className="text-sm font-medium">Discussion</p>
-      <PostComposer groupId={groupId} eventId={eventId} onPosted={refresh} />
+      <PostComposer eventId={eventId} onPosted={refresh} />
       {eventPosts?.length === 0 && (
         <p className="text-sm text-muted-foreground">No posts yet. Start the discussion!</p>
       )}
@@ -363,7 +363,7 @@ export default function EventDetailPage({ params }: { params: Promise<{ id: stri
       </div>
 
       {/* Discussion */}
-      <EventDiscussion eventId={id} groupId={event.groupId} currentUserId={myUserId} isGroupAdmin={isGroupAdmin} />
+      <EventDiscussion eventId={id} currentUserId={myUserId} isGroupAdmin={isGroupAdmin} />
 
       {/* Status controls (for event creator) */}
       {isEventCreator && (event.status === "open" || event.status === "draft") && (


### PR DESCRIPTION
## Summary

- **Bug**: Posting to an event discussion silently failed — the post appeared to submit but nothing was created.
- **Root cause**: `EventDiscussion` passed both `groupId` and `eventId` to `PostComposer`, which forwarded both to `feed.create`. The `feed.create` input schema enforces that `groupId` and `eventId` are mutually exclusive (`.refine((v) => !(v.groupId && v.eventId))`), so every submission triggered a `ZodError` → 400. The mutation had no `onError` UI feedback, so it appeared to do nothing.
- **Fix**: Remove `groupId` from `PostComposer` and `EventDiscussion` on the event detail page. The server already resolves `groupId` from the event record for authz — the client never needed to supply it.

## Security model

`feed.create` is behind `protectedProcedure` (authenticated). For event-scoped posts, the server looks up the event's `groupId` and verifies group membership via `groupMemberships` — unchanged by this fix.

## Known tradeoffs

None. This is a one-line client-side fix with no server-side changes.