### PR TITLE
feat(notifications): add T-1h RSVP reminder email (CAMP-129)

### DIFF
--- a/src/server/trpc/routers/events.ts
+++ b/src/server/trpc/routers/events.ts
@@ -164,11 +164,22 @@ export const eventsRouter = createTRPCRouter({
             .filter((id) => !rsvpdIds.has(id));
 
           const msUntilEvent = confirmedStartsAt.getTime() - Date.now();
-          const reminderDelay = msUntilEvent - 24 * 60 * 60 * 1000;
-          if (reminderDelay > 0 && unrsvpdIds.length > 0) {
+
+          // T-24h reminder
+          const reminder24hDelay = msUntilEvent - 24 * 60 * 60 * 1000;
+          if (reminder24hDelay > 0 && unrsvpdIds.length > 0) {
             void enqueueEventRsvpReminder(
               { eventId: input.id, eventTitle: event.title, groupName, recipientUserIds: unrsvpdIds },
-              reminderDelay
+              reminder24hDelay
+            );
+          }
+
+          // T-1h reminder (CAMP-129)
+          const reminder1hDelay = msUntilEvent - 60 * 60 * 1000;
+          if (reminder1hDelay > 0 && unrsvpdIds.length > 0) {
+            void enqueueEventRsvpReminder(
+              { eventId: input.id, eventTitle: event.title, groupName, recipientUserIds: unrsvpdIds },
+              reminder1hDelay
             );
           }
         }


### PR DESCRIPTION
## Summary

Adds a second RSVP reminder email scheduled 1 hour before a confirmed event, alongside the existing T-24h reminder. Closes #98.

On `updateStatus → confirmed`, both delayed jobs are now enqueued for members who haven't RSVPd:
- **T-24h**: existing, unchanged
- **T-1h**: new — `msUntilEvent - 3_600_000 ms` delay, same guard (`delay > 0 && unrsvpdIds.length > 0`)

No new job types, schema changes, or worker changes — both reminders reuse the existing `event_rsvp_reminder` BullMQ job and email template.

## Security model

`updateStatus` is behind `protectedProcedure` and enforces `event.createdBy === ctx.user.id` before any mutation or email dispatch — unchanged. `recipientUserIds` is derived server-side from `groupMemberships` and current RSVPs; no client-supplied recipient list.

## Known tradeoffs

- **Snapshot at confirm time**: `unrsvpdIds` is computed once when the event is confirmed. Members who RSVP after that point will still receive the reminders. This matches the spec ("Late RSVPs do not update reminder list", issue #97/#98).
- **No deduplication across the two jobs**: if a member RSVPs between T-24h and T-1h they'll still get the T-1h reminder. Acceptable at MVP scale; a follow-up sweep job could handle this later.
- **Skipped if event confirmed < 1h away**: `reminder1hDelay ≤ 0` guard prevents a negative-delay job, consistent with the T-24h guard.