### PR TITLE
fix(events): highlight current user's RSVP button (CAMP-072)

### DIFF
--- a/src/app/(app)/events/[id]/page.tsx
+++ b/src/app/(app)/events/[id]/page.tsx
@@ -262,6 +262,7 @@ export default function EventDetailPage({ params }: { params: Promise<{ id: stri
   if (!event) return <p className="text-muted-foreground text-sm">Event not found.</p>;
 
   const myUserId = me?.id ?? "";
+  const myRsvp = event.rsvps.find((r) => r.user.id === myUserId)?.status ?? null;
   const yesCount = event.rsvps.filter((r) => r.status === "yes").length;
   const maybeCount = event.rsvps.filter((r) => r.status === "maybe").length;
   const noCount = event.rsvps.filter((r) => r.status === "no").length;
@@ -304,7 +305,7 @@ export default function EventDetailPage({ params }: { params: Promise<{ id: stri
               <Button
                 key={s}
                 size="sm"
-                variant="outline"
+                variant={myRsvp === s ? "default" : "outline"}
                 disabled={upsertRsvp.isPending}
                 onClick={() => upsertRsvp.mutate({ eventId: id, status: s })}
               >


### PR DESCRIPTION
## Summary

Closes #50. The remaining item in CAMP-072 was that the current user's RSVP status wasn't highlighted on the event detail page buttons.

- Derive `myRsvp` from `event.rsvps` by matching `r.user.id === myUserId`
- Pass `variant={myRsvp === s ? "default" : "outline"}` to each RSVP button

No server changes — the data was already present in the `events.get` query response (`rsvps` includes `user.id`).

## Security model

`events.get` is behind `protectedProcedure` and asserts group membership before returning event data — unchanged. RSVP highlighting is purely client-side derived from already-fetched data.

## Known tradeoffs

None. This is a two-line UI fix.