### PR TITLE
feat(events): post-create nudge banner after proposing a session

### DIFF
--- a/src/app/(app)/events/[id]/page.tsx
+++ b/src/app/(app)/events/[id]/page.tsx
@@ -517,10 +517,18 @@ export default function EventDetailPage({ params }: { params: Promise<{ id: stri
             </Button>
             <Button
               size="sm"
-              onClick={() => { setStatusError(""); updateStatus.mutate({ id, status: "open" }); setShowNudge(false); }}
+              onClick={() => {
+                setStatusError("");
+                // Dismiss the banner only on success — if the mutation fails,
+                // statusError renders in the Event controls section below.
+                updateStatus.mutate(
+                  { id, status: "open" },
+                  { onSuccess: () => setShowNudge(false) }
+                );
+              }}
               disabled={updateStatus.isPending}
             >
-              Open for RSVPs
+              {updateStatus.isPending ? "Opening…" : "Open for RSVPs"}
             </Button>
             <button
               className="text-muted-foreground hover:text-foreground text-xs ml-1"

--- a/src/components/availability/group-overlap-view.tsx
+++ b/src/components/availability/group-overlap-view.tsx
@@ -295,7 +295,8 @@ function DayColumn({
         ));
       })}
 
-      {/* Yellow: 2+ members overlap */}
+      {/* Yellow: 2+ members overlap (z-10). Green renders after at z-20 so it
+          paints on top explicitly rather than relying on DOM sibling order. */}
       {yellowRanges.map(([start, end]) => (
         <button
           key={`y-${start}-${end}`}
@@ -310,11 +311,11 @@ function DayColumn({
         />
       ))}
 
-      {/* Green: all active members overlap (or 3+) */}
+      {/* Green: all active members overlap (or 3+) — z-20 keeps it above yellow */}
       {greenRanges.map(([start, end]) => (
         <button
           key={`g-${start}-${end}`}
-          className="absolute left-0 right-0 bg-green-400/30 hover:bg-green-400/50 border border-green-500/60 rounded cursor-pointer transition-colors z-10"
+          className="absolute left-0 right-0 bg-green-400/30 hover:bg-green-400/50 border border-green-500/60 rounded cursor-pointer transition-colors z-20"
           style={{
             top: start * SLOT_HEIGHT_PX + 1,
             height: (end - start) * SLOT_HEIGHT_PX - 2,


### PR DESCRIPTION
## Summary

Closes #194.

When a session is proposed from the group availability overlap view, the user lands on a blank draft event with no obvious next step. This PR adds a one-time "What's next?" banner that appears immediately after creation and offers the two most common next actions.

## What changed

**`src/components/availability/group-overlap-view.tsx`**
- `ProposeDialog` now navigates to `/events/:id?created=1` after success instead of plain `/events/:id`

**`src/app/(app)/events/[id]/page.tsx`**
- Added `useSearchParams` to detect `?created=1` on arrival
- Param is stripped via `window.history.replaceState` so it doesn't persist on refresh or back-navigation
- Banner renders when: param was present AND current user is the event creator AND event is still in `draft` status — so it never shows to other members or after the event is already open
- Banner offers three actions:
  - **Add a poll** — sets `forceOpen` on `CreatePollDialog`, which opens the dialog via a `useEffect` trigger
  - **Open for RSVPs** — calls the existing `updateStatus` mutation directly from the banner
  - **Dismiss** — hides the banner, no action taken
- `CreatePollDialog` extended with optional `forceOpen` / `onForceOpenChange` props so it can be opened by external callers without duplicating the dialog

## Security model

- Authentication: page is inside `(app)` layout which requires a valid session (`src/app/(app)/layout.tsx`)
- Authorisation: the banner's "Open for RSVPs" calls `events.updateStatus`, which is a `protectedProcedure` that checks the caller is the event creator before allowing the status transition — enforced server-side in `src/server/trpc/routers/events.ts`, not in this component
- The `?created=1` param is cosmetic client-side state only — it controls UI visibility, not any write path

## Known tradeoffs

- The banner appears based on client-side URL param detection. If the user manually adds `?created=1` to a draft event URL they created, they will see the banner. This is harmless — it only shows the same two actions that are already available on the page.
- `forceOpen` on `CreatePollDialog` is a `useEffect`-based trigger rather than a fully controlled open/close. This is intentional to avoid refactoring the dialog's internal state machine; the effect fires once on `forceOpen: true` and the dialog manages its own open state from there.