### PR TITLE
chore(seed): add Dan & Eve, availability schedules, dev-only guard

### DIFF
--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -23,7 +23,7 @@ All have password: **`password123`**
 
 | Email | Username | Notes |
 |---|---|---|
-| alice@campfire.local | @alice | Owner of "Friday Night Squad", friends with everyone. Free Mon/Wed/Fri/Sat evenings. |
+| alice@campfire.local | @alice | Owner of "Friday Night Squad". Free Mon/Wed/Fri/Sat evenings. |
 | bob@campfire.local | @bob | Member of "Friday Night Squad". Free Tue/Thu/Fri/Sat, late nights. |
 | carol@campfire.local | @carol | Member of "Friday Night Squad". Free Sun/Mon/Wed/Fri evenings. |
 | dan@campfire.local | @dan | Member of "Friday Night Squad". Free Sun/Mon/Fri/Sat, early evenings. |

--- a/src/server/db/seed.ts
+++ b/src/server/db/seed.ts
@@ -272,7 +272,7 @@ async function main() {
       continue;
     }
     await db.insert(availabilitySchedules).values({
-      id: `seed-avail-${userId}`,
+      id: `seed-avail-${userId.replace("seed-user-", "")}`,
       userId,
       timezone: "UTC",
       slots,


### PR DESCRIPTION
## Summary

Closes #196.

Improves the seed script for local development testing, specifically to support the group availability overlap view (CAMP-053 / PR #191) which needs multiple members with overlapping schedules to demonstrate the yellow/green colouring.

## What changed

**`src/server/db/seed.ts`**
- Added two new seed users: Dan (`dan@campfire.local`) and Eve (`eve@campfire.local`), each with a hashed password account row
- Added `SEED_AVAILABILITY` map with weekly schedule data for all 5 users — realistic evening/night slots (18:00–01:00 range), 3–4 nights free per week. Designed so Friday and Saturday always have 3+ members overlapping around 19:00–22:00 UTC
- Expanded friendship seeding to all-pairs (10 pairs for 5 users) — previously only alice↔bob, alice↔carol, bob↔carol
- Added Dan and Eve as members of Friday Night Squad
- Added `availabilitySchedules` to the destructured schema imports
- Added `NODE_ENV === "production"` guard at the top of `main()` — script exits with code 1 immediately if run outside a development environment

**`DEV_NOTES.md`**
- Updated test accounts table to list all 5 users with their availability patterns
- Added note that all five are friends with each other and members of Friday Night Squad

## Security model

- The prod guard is the only security-relevant change. The seed script has no auth — it writes directly to the DB via Drizzle. The guard prevents accidental execution in production where the DATABASE_URL would point at real data.
- No HTTP endpoints or tRPC procedures modified.

## Known tradeoffs

- Availability times are in UTC. The seed data is labelled as "UK evening" in comments but there is no timezone conversion — this is consistent with how the availability model works (member timezone is stored but expansion is UTC-based at MVP).
- The script is idempotent (skips existing rows) so re-running after Dan/Eve already exist is safe.