### PR TITLE
feat(availability): per-member filter toggle on group overlap view (CAMP-192)

### DIFF
--- a/src/components/availability/group-overlap-view.tsx
+++ b/src/components/availability/group-overlap-view.tsx
@@ -504,25 +504,45 @@ function DayColumn({
       <div className="absolute left-0 right-0 border-t border-border/40" style={{ top: 24 * HOUR_HEIGHT_PX }} />
 
       {/* Member availability bands.
-          Visible members render at opacity-60; hidden (visibility-off) members
-          render faintly at opacity-15 so the viewer can still reference their
-          schedule without them affecting the overlap threshold. */}
-      {memberData.map(({ userId, band, slots, hidden }, memberIdx) => {
-        const ranges = mergeSlots(slots[dateStr] ?? new Set());
-        const laneWidth = 100 / memberData.length;
-        return ranges.map(([start, end]) => (
-          <div
-            key={`${userId}-${start}-${end}`}
-            className={`absolute border-l-2 ${band} ${hidden ? "opacity-15" : "opacity-60"}`}
-            style={{
-              top: start * SLOT_HEIGHT_PX,
-              height: (end - start) * SLOT_HEIGHT_PX,
-              left: `${memberIdx * laneWidth}%`,
-              width: `${laneWidth}%`,
-            }}
-          />
-        ));
-      })}
+          Hidden members render full-width at opacity-15 behind the visible
+          lanes so the viewer can still reference their schedule. Visible members
+          are split into side-by-side lanes (existing behaviour). */}
+      {(() => {
+        const visibleMembers = memberData.filter((m) => !m.hidden);
+        const laneWidth = visibleMembers.length > 0 ? 100 / visibleMembers.length : 100;
+        const visibleIndexMap = new Map(visibleMembers.map((m, i) => [m.userId, i]));
+        return memberData.map(({ userId, band, slots, hidden }) => {
+          const ranges = mergeSlots(slots[dateStr] ?? new Set());
+          if (hidden) {
+            // Full-width faint band behind visible lanes
+            return ranges.map(([start, end]) => (
+              <div
+                key={`${userId}-${start}-${end}`}
+                className={`absolute border-l-2 ${band} opacity-15`}
+                style={{
+                  top: start * SLOT_HEIGHT_PX,
+                  height: (end - start) * SLOT_HEIGHT_PX,
+                  left: 0,
+                  width: "100%",
+                }}
+              />
+            ));
+          }
+          const memberIdx = visibleIndexMap.get(userId) ?? 0;
+          return ranges.map(([start, end]) => (
+            <div
+              key={`${userId}-${start}-${end}`}
+              className={`absolute border-l-2 ${band} opacity-60`}
+              style={{
+                top: start * SLOT_HEIGHT_PX,
+                height: (end - start) * SLOT_HEIGHT_PX,
+                left: `${memberIdx * laneWidth}%`,
+                width: `${laneWidth}%`,
+              }}
+            />
+          ));
+        });
+      })()}
 
       {/* Yellow: 2+ members overlap (z-10). Green renders after at z-20 so it
           paints on top explicitly rather than relying on DOM sibling order. */}
@@ -681,6 +701,7 @@ export function GroupOverlapView({ groupId }: { groupId: string }) {
                 <button
                   type="button"
                   title={isExcluded ? "Excluded from overlap — click to include" : "Included in overlap — click to exclude"}
+                  aria-label={isExcluded ? `Include ${m.user.name} in overlap` : `Exclude ${m.user.name} from overlap`}
                   onClick={() => toggleExcluded(m.user.id)}
                   className={`inline-block h-2.5 w-2.5 rounded-full shrink-0 transition-opacity ${isExcluded ? "opacity-25" : "opacity-100"} ${m.color.dot}`}
                 />
@@ -688,6 +709,7 @@ export function GroupOverlapView({ groupId }: { groupId: string }) {
                 <button
                   type="button"
                   title={isHidden ? "Band hidden — click to show" : "Click to hide band"}
+                  aria-label={isHidden ? `Show ${m.user.name}'s availability band` : `Hide ${m.user.name}'s availability band`}
                   onClick={() => toggleHidden(m.user.id)}
                   className="flex items-center gap-1 min-w-0"
                 >


### PR DESCRIPTION
## Summary

- Splits the member chip into two independent toggle actions: visibility (band show/hide) and overlap inclusion (counts toward green/yellow threshold)
- When a subset is selected for overlap, a "Showing overlap for: …" label makes the active threshold clear
- No schema or API changes — pure client-side state

## What changed

**`src/components/availability/group-overlap-view.tsx`**

### State model
Replaced single `disabledIds` set with two independent sets:
- `hiddenIds` — band not drawn on grid (cosmetic)
- `excludedIds` — not counted toward green/yellow overlap threshold

`overlapMembers` (used for `computeOverlapCounts`) now filters by `excludedIds` only. `totalActiveMembers` passed to `DayColumn` is `overlapMembers.length`.

### Member chip
Each chip now has two hit targets:
- **Coloured dot** (left): toggles overlap inclusion. Fades to 25% opacity when excluded.
- **Name/avatar** (right): toggles band visibility. Entire chip fades to 40% opacity when hidden.

Tooltip on each button explains what the action does.

### Grid bands
`DayColumn` receives a `hidden: boolean` flag per member. Hidden members render at `opacity-15` (faint, visible for reference) rather than being removed from the DOM. Visible members remain at `opacity-60`.

### Overlap label
When `excludedIds.size > 0`, a label appears below the chips:  
`Showing overlap for: Alice, Bob · Reset`  
"Reset" clears `excludedIds` in one click.

### Legend
Updated "Everyone free" → "All included members free" to reflect that the threshold now applies to the selected subset.

## Security model

No auth/authz changes. This is a client-side filter on data already loaded via `api.availability.groupOverlap` which is behind `protectedProcedure` and enforces group membership in `src/server/trpc/routers/availability.ts`.

## Known tradeoffs

- Hiding a member's band (visibility off) but keeping them included in the overlap threshold is a valid state. Their band renders faintly so the user can still see the schedule they're planning around. This is intentional — the two toggles are fully independent.
- The faint opacity (15%) was chosen to be visible but clearly subordinate to the full-opacity active bands. No interactivity is lost — overlap slots still render on top.

## Test plan

- [ ] Default state: all members visible, all included in overlap — green/yellow thresholds unchanged
- [ ] Exclude a member (dot click): their band remains visible faintly; green slots no longer require them; "Showing overlap for: …" label appears
- [ ] Reset: clears exclusions, all members back in threshold
- [ ] Hide a member (name click): chip fades to 40%, band disappears from grid; threshold unchanged if member is still included
- [ ] Exclude + hide: band gone, not counted in threshold
- [ ] "Showing overlap for" label only appears when at least one member is excluded
- [ ] Solo or 2-member group: existing green/yellow threshold logic unchanged