### PR TITLE
fix(games): derive IgdbResult from inferRouterOutputs to prevent drift

### DIFF
--- a/src/app/(app)/games/page.tsx
+++ b/src/app/(app)/games/page.tsx
@@ -3,6 +3,8 @@
 import { useState, useRef } from "react";
 import Link from "next/link";
 import { api } from "@/trpc/react";
+import type { inferRouterOutputs } from "@trpc/server";
+import type { AppRouter } from "@/server/trpc/routers/_app";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -28,14 +30,7 @@ const PLATFORM_LABELS: Record<Platform, string> = {
 
 // ── IGDB search result type ────────────────────────────────────────────────────
 
-type IgdbResult = {
-  igdbId: number;
-  title: string;
-  coverUrl: string | null;
-  genres: string[];
-  minPlayers: number | null;
-  maxPlayers: number | null;
-};
+type IgdbResult = inferRouterOutputs<AppRouter>["games"]["igdbSearch"][number];
 
 // ── Add game dialog ───────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Replaces the manually-defined `IgdbResult` type in [src/app/(app)/games/page.tsx](src/app/(app)/games/page.tsx) with one derived directly from the tRPC router output:

```ts
// Before (manual, drifts silently)
type IgdbResult = {
  igdbId: number;
  title: string;
  coverUrl: string | null;
  genres: string[];
  minPlayers: number | null;
  maxPlayers: number | null;
};

// After (derived, always in sync)
type IgdbResult = inferRouterOutputs<AppRouter>["games"]["igdbSearch"][number];
```

Uses `inferRouterOutputs<AppRouter>` from `@trpc/server` — the same pattern already used in `src/components/availability/group-overlap-view.tsx`.

## Security model

No behaviour change. Type-only fix. No routes, queries, or mutations are modified.

## Known tradeoffs

None. This is strictly safer than the previous approach.

Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)