### PR TITLE
refactor: export RouterOutputs from @/trpc/react

### DIFF
--- a/src/app/(app)/games/page.tsx
+++ b/src/app/(app)/games/page.tsx
@@ -2,9 +2,7 @@
 
 import { useState, useRef } from "react";
 import Link from "next/link";
-import { api } from "@/trpc/react";
-import type { inferRouterOutputs } from "@trpc/server";
-import type { AppRouter } from "@/server/trpc/routers/_app";
+import { api, type RouterOutputs } from "@/trpc/react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -30,7 +28,7 @@ const PLATFORM_LABELS: Record<Platform, string> = {
 
 // ── IGDB search result type ────────────────────────────────────────────────────
 
-type IgdbResult = inferRouterOutputs<AppRouter>["games"]["igdbSearch"][number];
+type IgdbResult = RouterOutputs["games"]["igdbSearch"][number];
 
 // ── Add game dialog ───────────────────────────────────────────────────────────
 

--- a/src/components/availability/group-overlap-view.tsx
+++ b/src/components/availability/group-overlap-view.tsx
@@ -19,11 +19,7 @@
 import { useState, useMemo, useCallback, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { format, addDays, parseISO, startOfWeek, endOfWeek } from "date-fns";
-import { api } from "@/trpc/react";
-import type { inferRouterOutputs } from "@trpc/server";
-import type { AppRouter } from "@/server/trpc/routers/_app";
-
-type RouterOutputs = inferRouterOutputs<AppRouter>;
+import { api, type RouterOutputs } from "@/trpc/react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
   Dialog,

--- a/src/trpc/react.tsx
+++ b/src/trpc/react.tsx
@@ -2,11 +2,13 @@
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { createTRPCReact, httpBatchLink } from "@trpc/react-query";
+import type { inferRouterOutputs } from "@trpc/server";
 import { useState } from "react";
 import superjson from "superjson";
 import type { AppRouter } from "@/server/trpc/routers/_app";
 
 export const api = createTRPCReact<AppRouter>();
+export type RouterOutputs = inferRouterOutputs<AppRouter>;
 
 function makeQueryClient() {
   return new QueryClient({


### PR DESCRIPTION
## Summary

Adds `RouterOutputs = inferRouterOutputs<AppRouter>` as a named export from `src/trpc/react.tsx`, then updates both existing callsites to use it.

**Before** — client components needed two extra imports:
```ts
import type { inferRouterOutputs } from "@trpc/server";
import type { AppRouter } from "@/server/trpc/routers/_app";
type RouterOutputs = inferRouterOutputs<AppRouter>;
```

**After** — one import alongside `api`:
```ts
import { api, type RouterOutputs } from "@/trpc/react";
```

Files updated:
- [src/trpc/react.tsx](src/trpc/react.tsx) — added export
- [src/app/(app)/games/page.tsx](src/app/(app)/games/page.tsx) — simplified (follow-on from #207)
- [src/components/availability/group-overlap-view.tsx](src/components/availability/group-overlap-view.tsx) — simplified

## Security model

Type-only change. No runtime behaviour modified.

## Known tradeoffs

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)