### PR TITLE
fix(infra): singleton postgres client to prevent hot-reload session drops (TD-023)

### DIFF
--- a/src/server/db/index.ts
+++ b/src/server/db/index.ts
@@ -3,5 +3,14 @@ import postgres from "postgres";
 import { env } from "@/env";
 import * as schema from "./schema";
 
-const client = postgres(env.DATABASE_URL);
+// Reuse the postgres client across hot-reloads in development.
+// Without this, each HMR cycle creates a new connection pool, exhausting the
+// previous one and causing session/query errors until the old pool times out.
+// In production the module is only ever evaluated once, so the guard is a no-op.
+const globalForDb = globalThis as unknown as { pgClient?: postgres.Sql };
+
+const client = globalForDb.pgClient ?? postgres(env.DATABASE_URL);
+
+if (env.NODE_ENV !== "production") globalForDb.pgClient = client;
+
 export const db = drizzle(client, { schema });


### PR DESCRIPTION
## Summary

Applies the standard Next.js HMR singleton pattern to the postgres client in `src/server/db/index.ts`.

**Root cause:** In development, Next.js hot-module replacement re-evaluates server modules on each file save. Without a singleton, every HMR cycle creates a new `postgres()` connection pool and abandons the previous one. The abandoned pool holds open connections until they time out, and meanwhile better-auth session queries on the old pool fail — causing the intermittent session drops described in TD-023.

**Fix:** Cache the `postgres.Sql` client on `globalThis` in non-production environments. On the next HMR cycle, the cached client is reused instead of a new one being created. In production the module is only ever evaluated once, so the guard is a strict no-op.

This is the same pattern used by the [official Drizzle + Next.js docs](https://orm.drizzle.team/docs/connect-neon#nextjs-edge-runtime) and the T3 stack.

## Security model

No auth or authorisation changes. This is a connection lifecycle fix only. The `globalThis` cache is process-local and never exposed to clients.

## Known tradeoffs

None. The guard is conditional on `NODE_ENV !== "production"` so it cannot affect prod behaviour.

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)