### PR TITLE
feat(games): Steam Store price snapshot at poll creation (CAMP-110)

### DIFF
--- a/src/app/(app)/games/[id]/page.tsx
+++ b/src/app/(app)/games/[id]/page.tsx
@@ -184,6 +184,32 @@ export default function GameDetailPage({ params }: { params: Promise<{ id: strin
           {game.description && (
             <p className="text-sm text-muted-foreground">{game.description}</p>
           )}
+          {game.priceDataJson && (
+            <div className="flex items-center gap-2 pt-0.5">
+              {game.priceDataJson.discountPercent > 0 ? (
+                <>
+                  <Badge variant="secondary" className="text-xs bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-100">
+                    -{game.priceDataJson.discountPercent}%
+                  </Badge>
+                  <span className="text-sm line-through text-muted-foreground">
+                    {game.priceDataJson.initialFormatted}
+                  </span>
+                  <span className="text-sm font-semibold text-green-700 dark:text-green-300">
+                    {game.priceDataJson.finalFormatted}
+                  </span>
+                </>
+              ) : (
+                <span className="text-sm text-muted-foreground">
+                  {game.priceDataJson.finalFormatted}
+                </span>
+              )}
+              {game.priceSnapshotAt && (
+                <span className="text-xs text-muted-foreground">
+                  · as of {format(new Date(game.priceSnapshotAt), "MMM d")}
+                </span>
+              )}
+            </div>
+          )}
         </div>
       </div>
 

--- a/src/server/db/schema/games.ts
+++ b/src/server/db/schema/games.ts
@@ -11,6 +11,15 @@ import {
 import { sql } from "drizzle-orm";
 import { user } from "./auth";
 
+export type SteamPriceData = {
+  currency: string;
+  initial: number;       // cents
+  final: number;         // cents (after discount)
+  discountPercent: number;
+  initialFormatted: string;
+  finalFormatted: string;
+};
+
 export const gameSourceEnum = pgEnum("game_source", ["manual", "igdb", "steam_app"]);
 
 export const gamePlatformEnum = pgEnum("game_platform", [
@@ -37,6 +46,9 @@ export const games = pgTable(
     externalId: text("external_id"),
     steamAppId: text("steam_app_id"),
     metadataJson: jsonb("metadata_json"),
+    // Steam Store price snapshot (snapshotted at poll creation time)
+    priceDataJson: jsonb("price_data_json").$type<SteamPriceData>(),
+    priceSnapshotAt: timestamp("price_snapshot_at"),
     createdAt: timestamp("created_at").notNull().defaultNow(),
     updatedAt: timestamp("updated_at").notNull().defaultNow(),
   },

--- a/src/server/lib/steam-price.ts
+++ b/src/server/lib/steam-price.ts
@@ -1,0 +1,87 @@
+import { eq } from "drizzle-orm";
+import { db } from "@/server/db";
+import { games, type SteamPriceData } from "@/server/db/schema";
+
+type SteamPriceOverview = {
+  currency: string;
+  initial: number;
+  final: number;
+  discount_percent: number;
+  initial_formatted: string;
+  final_formatted: string;
+};
+
+type SteamAppDetailsResponse = {
+  [appId: string]: {
+    success: boolean;
+    data?: {
+      is_free?: boolean;
+      price_overview?: SteamPriceOverview;
+    };
+  };
+};
+
+/**
+ * Fetch the current Steam Store price for a game and save it to the DB.
+ *
+ * Uses the unauthenticated store API (no API key required).
+ * cc=us returns USD prices; free games have no price_overview.
+ * Silently no-ops on fetch failure — price data is best-effort.
+ */
+export async function snapshotSteamPrice(gameId: string, steamAppId: string): Promise<void> {
+  const url = new URL("https://store.steampowered.com/api/appdetails");
+  url.searchParams.set("appids", steamAppId);
+  url.searchParams.set("filters", "price_overview");
+  url.searchParams.set("cc", "us");
+
+  let res: Response;
+  try {
+    res = await fetch(url);
+  } catch (err) {
+    console.warn(`[steam-price] fetch failed for appId ${steamAppId}:`, err);
+    return;
+  }
+
+  if (!res.ok) {
+    console.warn(`[steam-price] Steam Store API returned ${res.status} for appId ${steamAppId}`);
+    return;
+  }
+
+  let json: SteamAppDetailsResponse;
+  try {
+    json = (await res.json()) as SteamAppDetailsResponse;
+  } catch {
+    console.warn(`[steam-price] failed to parse response for appId ${steamAppId}`);
+    return;
+  }
+
+  const appData = json[steamAppId];
+  if (!appData?.success) {
+    console.warn(`[steam-price] Steam returned success:false for appId ${steamAppId}`);
+    return;
+  }
+
+  const price = appData.data?.price_overview;
+  if (!price) {
+    // Free game or no price data — clear any stale price
+    await db
+      .update(games)
+      .set({ priceDataJson: null, priceSnapshotAt: new Date() })
+      .where(eq(games.id, gameId));
+    return;
+  }
+
+  const priceData: SteamPriceData = {
+    currency: price.currency,
+    initial: price.initial,
+    final: price.final,
+    discountPercent: price.discount_percent,
+    initialFormatted: price.initial_formatted,
+    finalFormatted: price.final_formatted,
+  };
+
+  await db
+    .update(games)
+    .set({ priceDataJson: priceData, priceSnapshotAt: new Date() })
+    .where(eq(games.id, gameId));
+}

--- a/src/server/trpc/routers/polls.ts
+++ b/src/server/trpc/routers/polls.ts
@@ -7,6 +7,7 @@ import { db } from "@/server/db";
 import { polls, pollOptions, pollVotes, events, groupMemberships, groups } from "@/server/db/schema";
 import { enqueuePollOpened, enqueuePollClosed } from "@/server/jobs/email-jobs";
 import { enqueueClosePoll } from "@/server/jobs/poll-jobs";
+import { snapshotSteamPrice } from "@/server/lib/steam-price";
 import { env } from "@/env";
 
 async function assertPollMember(pollId: string, userId: string) {
@@ -96,6 +97,25 @@ export const pollsRouter = createTRPCRouter({
           endsAt: opt.endsAt ? new Date(opt.endsAt) : null,
           sortOrder: opt.sortOrder ?? i,
         });
+      }
+
+      // Fire-and-forget Steam price snapshots for game poll options.
+      // Only runs for game polls with gameId options that have a steamAppId.
+      // Failures are swallowed — price data is best-effort and must not block poll creation.
+      if (input.type === "game") {
+        const gameIds = input.options.map((o) => o.gameId).filter((id): id is string => !!id);
+        if (gameIds.length > 0) {
+          const gamesWithSteam = await db.query.games.findMany({
+            where: (g, { inArray, and: a, isNotNull }) =>
+              a(inArray(g.id, gameIds), isNotNull(g.steamAppId)),
+            columns: { id: true, steamAppId: true },
+          });
+          for (const game of gamesWithSteam) {
+            void snapshotSteamPrice(game.id, game.steamAppId!).catch((err: unknown) =>
+              console.error(`[poll] steam price snapshot failed for game ${game.id}:`, err),
+            );
+          }
+        }
       }
 
       // Schedule auto-close if closesAt is set.


### PR DESCRIPTION
## Summary

When a game poll is created, snapshots current Steam Store prices for any options that have a `steamAppId`. Prices are displayed on the game detail page with discount badges when on sale. No API key required — uses the public unauthenticated Steam Store API.

## What changed

**Schema** (`src/server/db/schema/games.ts`):
- `price_data_json` (jsonb, nullable) — `SteamPriceData` type: currency, initial/final cents, discountPercent, formatted strings
- `price_snapshot_at` (timestamp, nullable) — when the snapshot was last taken
- `SteamPriceData` type exported from schema for use across the app
- Migration: `drizzle/0013_omniscient_sabra.sql`

**Steam price fetcher** (`src/server/lib/steam-price.ts`):
- `snapshotSteamPrice(gameId, steamAppId)` — fetches `https://store.steampowered.com/api/appdetails?appids=<id>&filters=price_overview&cc=us`
- No API key required (public endpoint)
- Free games: clears `priceDataJson`, updates `priceSnapshotAt`
- All failures are silent (console.warn + early return) — price is best-effort support data, not core functionality

**Poll creation** (`src/server/trpc/routers/polls.ts`):
- After inserting poll options for a `game` type poll, queries for options with `gameId` values that have a non-null `steamAppId`
- Fires `snapshotSteamPrice` for each in a fire-and-forget `.catch()` block
- Does not block or delay poll creation response

**Game detail page** (`src/app/(app)/games/[id]/page.tsx`):
- Displays price when `priceDataJson` is present
- Sale: green discount badge + crossed-out original price + discounted price
- Full price: plain formatted price string
- Snapshot date shown as "as of MMM D"

## Security model

**Authentication:** No new procedures — price snapshotting happens server-side as part of `polls.create` (already `protectedProcedure`).

**No user input reaches the Steam API** — `steamAppId` is taken from the DB (set during IGDB import or Steam library sync), not from user input. The price fetcher only accepts a `steamAppId` string already stored in the DB.

**Price data is display-only** — the stored `priceDataJson` is never used for payment or entitlement logic.

## Known tradeoffs

- **cc=us hardcoded** — prices are in USD. A future improvement could use the user's locale/currency. Acceptable for MVP.
- **Snapshot only at poll creation** — prices can go stale. A refresh job (e.g. triggered by the recurring event generator or a daily sweep) could be added later. The snapshot date is shown so users know how fresh the data is.
- **No snapshot for existing games without polls** — the initial snapshot is triggered by poll creation. Games added via IGDB import or Steam library sync don't get a price snapshot until a poll is created for them.
- **Free games** — the Steam Store API returns no `price_overview` for free games. These clear `priceDataJson` (no price shown).

## Testing checklist

- [ ] Create a game poll with Steam-linked game options — prices appear on game detail page after a moment
- [ ] On-sale game shows discount badge, crossed-out original, discounted price
- [ ] Free game shows no price
- [ ] Non-Steam game (manual or IGDB without `steamAppId`) shows no price
- [ ] Price snapshot failure doesn't break poll creation

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)