### PR TITLE
feat(games): Steam CDN header image for cover art (CAMP-117)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -54,7 +54,13 @@ const nextConfig: NextConfig = {
   },
   transpilePackages: ["@fullcalendar"],
   images: {
-    remotePatterns: minioRemotePatterns(),
+    remotePatterns: [
+      ...minioRemotePatterns(),
+      // Steam CDN — game header/capsule images
+      { protocol: "https", hostname: "cdn.akamai.steamstatic.com", pathname: "/steam/apps/**" },
+      // IGDB / Twitch CDN — game cover art
+      { protocol: "https", hostname: "images.igdb.com", pathname: "/**" },
+    ],
   },
 };
 

--- a/src/worker/processors/steam.ts
+++ b/src/worker/processors/steam.ts
@@ -26,7 +26,6 @@ export async function processSteamJob(job: Job<SteamJobPayload>): Promise<void> 
 type SteamOwnedGame = {
   appid: number;
   name?: string;
-  img_icon_url?: string;
   playtime_forever?: number;
 };
 
@@ -124,9 +123,9 @@ async function upsertBatch(userId: string, steamGames: SteamOwnedGame[]): Promis
       externalSource: "steam_app" as const,
       externalId: String(g.appid),
       steamAppId: String(g.appid),
-      coverUrl: g.img_icon_url
-        ? `https://media.steampowered.com/steamcommunity/public/images/apps/${g.appid}/${g.img_icon_url}.jpg`
-        : null,
+      // header.jpg is the standard 460×215 store banner — universally available,
+      // no API key required, and far more recognisable than the 32px icon URL.
+      coverUrl: `https://cdn.akamai.steamstatic.com/steam/apps/${g.appid}/header.jpg`,
     }));
 
     await db.insert(games).values(newRows).onConflictDoNothing();


### PR DESCRIPTION
## Summary

- Replaces `img_icon_url` (a 32×32 game icon from `GetOwnedGames`) with `https://cdn.akamai.steamstatic.com/steam/apps/{appid}/header.jpg` — the standard 460×215 Steam store header image
- `header.jpg` is universally available for all published Steam apps, requires no API key, and is served from Akamai CDN
- Removes the now-unused `img_icon_url` field from `SteamOwnedGame` type
- Adds Steam CDN and IGDB CDN hostnames to `next/image` `remotePatterns` (forward-looking, for when `<img>` is replaced with `next/image`)
- 561 existing `steam_app` rows backfilled directly via psql (drizzle/ is gitignored in this repo — migrations are applied locally)

## Security model

- No new tRPC procedures or auth changes
- `next.config.ts` `remotePatterns` addition is an allowlist — only adds `cdn.akamai.steamstatic.com` and `images.igdb.com` as permitted `/_next/image` sources
- The cover URL is derived from the stored `steamAppId` (our own data), not from user input

## Known tradeoffs

- **`header.jpg` is landscape (460×215)** — the current UI uses `object-cover` on a portrait container (`h-28 w-20`), which crops the header. This is acceptable for now; a follow-on can switch to `library_600x900.jpg` per-game if it exists, or use a portrait capsule. The header image is still vastly more recognisable than a 32px icon.
- **Backfill not in a migration file** — `drizzle/` is gitignored so the SQL is not committed. The UPDATE was applied directly: `UPDATE games SET cover_url = ... WHERE external_source = 'steam_app' AND (cover_url IS NULL OR cover_url LIKE '%media.steampowered.com%')` — 561 rows affected.