### PR TITLE
feat(nav): responsive mobile bottom navigation bar (CAMP-126)

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -42,7 +42,7 @@ export default async function AppLayout({ children }: { children: React.ReactNod
         </div>
       </header>
       {/* pb-16 on mobile so content clears the fixed bottom nav bar */}
-      <main className="mx-auto w-full max-w-4xl flex-1 px-4 py-6 pb-20 md:pb-6">{children}</main>
+      <main className="mx-auto w-full max-w-4xl flex-1 px-4 pt-6 pb-20 md:pb-6">{children}</main>
       <MobileNav />
     </div>
   );

--- a/src/components/nav/mobile-nav.tsx
+++ b/src/components/nav/mobile-nav.tsx
@@ -7,7 +7,7 @@ import { api } from "@/trpc/react";
 // Lucide-style inline SVG icons — avoids adding a dependency
 function IconFeed() {
   return (
-    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
       <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
       <polyline points="9 22 9 12 15 12 15 22" />
     </svg>
@@ -16,7 +16,7 @@ function IconFeed() {
 
 function IconGroups() {
   return (
-    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
       <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
       <circle cx="9" cy="7" r="4" />
       <path d="M23 21v-2a4 4 0 0 0-3-3.87" />
@@ -27,7 +27,7 @@ function IconGroups() {
 
 function IconEvents() {
   return (
-    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
       <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
       <line x1="16" y1="2" x2="16" y2="6" />
       <line x1="8" y1="2" x2="8" y2="6" />
@@ -38,7 +38,7 @@ function IconEvents() {
 
 function IconGames() {
   return (
-    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
       <line x1="6" y1="12" x2="10" y2="12" />
       <line x1="8" y1="10" x2="8" y2="14" />
       <circle cx="15" cy="13" r="1" />
@@ -50,7 +50,7 @@ function IconGames() {
 
 function IconNotifications() {
   return (
-    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
       <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />
       <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" />
     </svg>


### PR DESCRIPTION
## Summary

The horizontal header nav overflows on mobile viewports. This PR adds a fixed bottom navigation bar for screens below `md` (768px) and hides the header nav links on mobile.

**Mobile (<768px):**
- Header: logo + UserMenu only
- Fixed bottom bar (64px): Feed · Groups · Events · Games · Alerts
- Unread notification count badge on Alerts tab
- `main` gets `pb-20` to clear the fixed bar

**Desktop (≥768px):** unchanged — horizontal header nav, notification bell, user menu.

## Security model

No auth or data changes. `MobileNav` is a presentational client component that reads from the existing `notifications.unreadCount` query (already used by `NotificationBell`).

## Known tradeoffs

- **Five destinations only** — Friends, Availability, Find People, Settings are accessible via the desktop nav on wider viewports, and via UserMenu/direct URL on mobile. A "More" overflow sheet can be added later.
- **No iOS safe-area inset** — `padding-bottom: env(safe-area-inset-bottom)` is not applied (no Tailwind plugin configured). The bar sits at the very bottom; home indicator on iPhone overlaps slightly. Acceptable for now — can add the plugin in a follow-on.
- **Inline SVG icons** — lucide-react is available but this avoids importing the full icon set for five simple icons. Can be replaced with lucide imports when the icon set is used more broadly.