### PR TITLE
feat(games): search/filter within My Games library (CAMP-119)

### DIFF
--- a/src/app/(app)/games/page.tsx
+++ b/src/app/(app)/games/page.tsx
@@ -323,13 +323,11 @@ export default function GamesPage() {
   const [search, setSearch] = useState("");
 
   // Debounce search input — update the query param 300ms after the user stops typing.
-  // Skip the effect when both values are already empty to avoid a no-op state update on mount.
   useEffect(() => {
     const trimmed = searchInput.trim();
-    if (trimmed === search) return;
     const t = setTimeout(() => setSearch(trimmed), 300);
     return () => clearTimeout(t);
-  }, [searchInput, search]);
+  }, [searchInput]);
 
   const utils = api.useUtils();
 

--- a/src/server/trpc/routers/games.ts
+++ b/src/server/trpc/routers/games.ts
@@ -219,11 +219,13 @@ export const gamesRouter = createTRPCRouter({
         const matchingGames = await db
           .select({ id: games.id })
           .from(games)
-          .where(ilike(games.title, `%${escaped}%`));
+          .where(ilike(games.title, `%${escaped}%`))
+          .orderBy(games.title);
         searchGameIds = matchingGames.map((g) => g.id);
         // If no games match the search, return early — no ownerships to fetch.
         if (searchGameIds.length === 0) return { items: [], nextCursor: undefined, total: 0 };
         // Guard: very common search terms can match thousands of catalog entries.
+        // ORDER BY title above makes truncation deterministic (alphabetical prefix).
         // At MVP scale (Steam sync caps at ~2000 games/user) the IN clause is still
         // manageable, but this cap prevents unbounded query size.
         if (searchGameIds.length > 500) searchGameIds = searchGameIds.slice(0, 500);


### PR DESCRIPTION
## Summary

- Adds an optional `search` param to the `myGames` tRPC procedure — resolved via `ilike` on `games.title` before filtering ownerships
- Adds a debounced (300ms) search input above the platform filters on the My Games page
- Works in combination with platform filter and show-hidden toggle
- Empty search shows the full paginated library unchanged

## Security model

- `myGames` is behind `protectedProcedure`. Ownership rows are always scoped to `ctx.user.id` — the search param only further restricts which gameIds are considered, it cannot leak another user's library.
- Search uses parameterised `ilike` (Drizzle ORM); no raw SQL interpolation.

## Implementation notes

The search resolves in two steps:
1. Query `games` table for IDs matching `%search%` (ilike)
2. If matches exist, pass them as an `inArray` filter on `gameOwnerships.gameId`

Early return with `{ items: [], nextCursor: undefined, total: 0 }` when the ilike finds zero matching games — avoids unnecessary ownership query.

## Known tradeoffs

- The search-then-filter pattern does two round-trips to the DB when a search term is present. At MVP scale this is negligible; a single join-based query could replace it later if needed (tracked in the existing tech-debt issue #199 / `TODO(tech-debt)` comment in the router).
- The ilike is case-insensitive but not accent-insensitive. Full-text search is out of scope for MVP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)