### PR TITLE
fix(ux): constrain page content width for list pages

### DIFF
--- a/src/app/(app)/events/page.tsx
+++ b/src/app/(app)/events/page.tsx
@@ -234,7 +234,7 @@ export default function EventsPage() {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="max-w-2xl space-y-6">
       <h1 className="text-2xl font-bold">Events</h1>
 
       {/* Group tabs */}

--- a/src/app/(app)/friends/page.tsx
+++ b/src/app/(app)/friends/page.tsx
@@ -26,7 +26,7 @@ export default function FriendsPage() {
   const friends = data?.friends ?? [];
 
   return (
-    <div className="space-y-6">
+    <div className="max-w-2xl space-y-6">
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold">Friends</h1>

--- a/src/app/(app)/games/page.tsx
+++ b/src/app/(app)/games/page.tsx
@@ -359,7 +359,7 @@ export default function GamesPage() {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="max-w-3xl space-y-6">
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold">My Games</h1>
@@ -472,7 +472,7 @@ export default function GamesPage() {
         />
       ) : viewMode === "grid" ? (
         <>
-          <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 gap-3">
+          <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-3">
             {allItems.map((g) => (
               <div key={g.id} className="group relative">
                 <Link href={`/games/${g.id}`} className="block">

--- a/src/app/(app)/groups/page.tsx
+++ b/src/app/(app)/groups/page.tsx
@@ -92,7 +92,7 @@ export default function GroupsPage() {
   const { data: myGroups = [], isLoading, refetch } = api.groups.list.useQuery();
 
   return (
-    <div className="space-y-6">
+    <div className="max-w-2xl space-y-6">
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold">Groups</h1>

--- a/src/app/(app)/people/page.tsx
+++ b/src/app/(app)/people/page.tsx
@@ -44,7 +44,7 @@ export default function PeoplePage() {
   }
 
   return (
-    <div className="space-y-8">
+    <div className="max-w-2xl space-y-8">
       <div>
         <h1 className="text-2xl font-bold">Find people</h1>
         <p className="text-muted-foreground">Search for friends by username or display name.</p>


### PR DESCRIPTION
## Summary

Closes #245, closes #251.

With the three-column shell (#258), the global `max-w-4xl` was removed from the app layout — pages now own their own width. List-only pages were stretching to fill the full ~700px center column, causing uncomfortably long line lengths and ragged layouts.

## Changes

| Page | Change |
|---|---|
| `/friends` | `max-w-2xl` added |
| `/groups` | `max-w-2xl` added |
| `/events` | `max-w-2xl` added |
| `/people` | `max-w-2xl` added |
| `/games` | `max-w-3xl` added; card grid reduced from `md:grid-cols-6` → `md:grid-cols-5` |

## Not changed (already correct or intentional)

- `/notifications` — already `max-w-2xl`
- `/availability` — full-width intentional (weekly grid editor needs the space)
- `/settings` — already `max-w-xl`
- `/u/[username]` — already `max-w-lg`
- `/feed` — intentionally fills the center column

## Security model

Presentation-only changes — no auth, no data access, no mutations.

## Known tradeoffs

Games grid: `md:grid-cols-5` is slightly fewer columns than before (`6`), but with the left (~240px) and right (~240px) panels flanking the center, 6 columns at typical desktop widths was cramped. 5 columns fits cleanly within `max-w-3xl` (768px).