### PR TITLE
fix(events): correct empty state heading copy bug

### DIFF
--- a/src/app/(app)/events/page.tsx
+++ b/src/app/(app)/events/page.tsx
@@ -213,7 +213,7 @@ export default function EventsPage() {
               <line x1="16" y1="2" x2="16" y2="6" /><line x1="8" y1="2" x2="8" y2="6" /><line x1="3" y1="10" x2="21" y2="10" />
             </svg>
           }
-          heading="No groups yet"
+          heading="No events yet"
           description="Join or create a group to start planning gaming sessions."
           action={<Button asChild size="sm"><Link href="/groups">Go to Groups</Link></Button>}
         />


### PR DESCRIPTION
## Summary

Fixes a copy bug on the Events page empty state: the heading read "No groups yet" instead of "No events yet".

The empty state is shown when the user has no groups (and therefore cannot have any events). The description and CTA ("Go to Groups") are correct — only the heading was wrong.

Introduced in PR #260 (card surface polish).

## Security model

UI-only change. No data access.

Closes #263 (if filed)