### PR TITLE
feat(nav): active state + full nav links in left panel

### DIFF
--- a/src/components/nav/profile-card.tsx
+++ b/src/components/nav/profile-card.tsx
@@ -269,7 +269,7 @@ function StatRow({
           : "text-muted-foreground hover:text-foreground hover:bg-accent"
       }`}
     >
-      <span className="font-medium">{label}</span>
+      <span className={active ? "font-semibold" : "font-medium"}>{label}</span>
       <span className="flex items-center gap-1 tabular-nums">
         {count}
         <span className={`transition-opacity text-[10px] ${active ? "opacity-60" : "opacity-0 group-hover:opacity-60"}`}>→</span>


### PR DESCRIPTION
## Summary

Fixes two navigation gaps found during a full UX audit (#264, #265):

**#264 — No active/current-page indicator:**
All nav items now use `usePathname()` to show which page you're on. Active items get `bg-accent text-foreground font-semibold`. Feed uses exact match (`pathname === "/feed"`); all other routes use `startsWith` so sub-pages highlight the parent (e.g. `/groups/abc` keeps Groups highlighted).

Applies to: stat rows (Friends, Groups, Games), primary nav links, and utility links (Notifications, Settings).

**#265 — Missing nav links to Events, Availability, People:**
Added a `<nav>` section with icon+label rows for: Feed, Events, Availability, Find people. These routes were previously unreachable from the sidebar. Separated from utility links by a thin `border-t` divider.

**New left panel structure (top to bottom):**
1. Profile card (avatar, name, status dropdown, Friends/Groups/Games stat rows)
2. Primary nav: Feed · Events · Availability · Find people
3. Divider
4. Utility: Notifications (with unread badge) · Settings · Sign out
5. Theme toggle

## Security model

Client-side navigation only. No data access changes. `usePathname()` reads the current URL client-side — no server involvement. All existing `protectedProcedure` guards remain unchanged.

## Known tradeoffs

- The `NavLink` component is a new internal function in `profile-card.tsx`. If the panel grows significantly, it could be extracted. Left inline for now per the "no premature abstractions" rule.
- `/u/[username]` routes (other-user profiles) do not highlight any nav item — acceptable, as these are not primary nav destinations.

Closes #264
Closes #265