### PR TITLE
feat(ux): contextual right panel + per-page titles

### DIFF
--- a/src/app/(app)/availability/layout.tsx
+++ b/src/app/(app)/availability/layout.tsx
@@ -1,0 +1,7 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = { title: "Availability" };
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/app/(app)/events/layout.tsx
+++ b/src/app/(app)/events/layout.tsx
@@ -1,0 +1,7 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = { title: "Events" };
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/app/(app)/feed/layout.tsx
+++ b/src/app/(app)/feed/layout.tsx
@@ -1,0 +1,7 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = { title: "Feed" };
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/app/(app)/friends/layout.tsx
+++ b/src/app/(app)/friends/layout.tsx
@@ -1,0 +1,7 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = { title: "Friends" };
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/app/(app)/games/layout.tsx
+++ b/src/app/(app)/games/layout.tsx
@@ -1,0 +1,7 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = { title: "My Games" };
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/app/(app)/groups/layout.tsx
+++ b/src/app/(app)/groups/layout.tsx
@@ -1,0 +1,7 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = { title: "Groups" };
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { auth } from "@/server/auth";
@@ -5,6 +6,10 @@ import { LeftPanel } from "@/components/nav/left-panel";
 import { RightPanel } from "@/components/nav/right-panel";
 import { CampfireLogo } from "@/components/nav/campfire-logo";
 import { MobileNav } from "@/components/nav/mobile-nav";
+
+export const metadata: Metadata = {
+  title: { template: "%s — Campfire", default: "Campfire" },
+};
 
 export default async function AppLayout({ children }: { children: React.ReactNode }) {
   let session;

--- a/src/app/(app)/notifications/layout.tsx
+++ b/src/app/(app)/notifications/layout.tsx
@@ -1,0 +1,7 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = { title: "Notifications" };
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/app/(app)/people/layout.tsx
+++ b/src/app/(app)/people/layout.tsx
@@ -1,0 +1,7 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = { title: "Find People" };
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/app/(app)/profile/layout.tsx
+++ b/src/app/(app)/profile/layout.tsx
@@ -1,0 +1,7 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = { title: "My Profile" };
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/app/(app)/settings/layout.tsx
+++ b/src/app/(app)/settings/layout.tsx
@@ -1,0 +1,7 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = { title: "Settings" };
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/components/nav/right-panel.tsx
+++ b/src/components/nav/right-panel.tsx
@@ -1,6 +1,17 @@
+"use client";
+
+import { usePathname } from "next/navigation";
 import { UpcomingEventsPanel } from "@/components/feed/upcoming-events-panel";
 
+// Pages where the right panel adds no contextual value.
+const HIDDEN_ON = ["/settings", "/notifications", "/people"];
+
 export function RightPanel() {
+  const pathname = usePathname();
+  const hidden = HIDDEN_ON.some((p) => pathname === p || pathname.startsWith(`${p}/`));
+
+  if (hidden) return null;
+
   return (
     <aside className="hidden lg:block w-60 shrink-0 sticky top-0 h-screen overflow-y-auto py-6 px-4 border-l">
       <UpcomingEventsPanel />


### PR DESCRIPTION
## Summary

Two UX polish fixes from the audit:

### #266 — Right panel hidden on non-feed pages

`RightPanel` is now a `"use client"` component that reads `usePathname()` and returns `null` on pages where the upcoming events widget has no contextual relevance: `/settings`, `/notifications`, `/people` (and any sub-routes of those).

Previously the panel appeared on every page in the app including settings and search. On those pages it consumed 240px of horizontal space and showed content irrelevant to the current task.

The panel continues to show on all feed/social pages: Feed, Friends, Groups, Events, Games, Availability, Profile.

### #267 — Per-page `<title>` tags

Added `title: { template: "%s — Campfire", default: "Campfire" }` to the `(app)` layout metadata. Added a minimal per-route `layout.tsx` to each page folder exporting the appropriate title string:

| Route | Title |
|---|---|
| /feed | Feed — Campfire |
| /friends | Friends — Campfire |
| /groups | Groups — Campfire |
| /events | Events — Campfire |
| /games | My Games — Campfire |
| /availability | Availability — Campfire |
| /people | Find People — Campfire |
| /settings | Settings — Campfire |
| /notifications | Notifications — Campfire |
| /profile | My Profile — Campfire |

Each per-route `layout.tsx` is a pass-through server component (`<>{children}</>`) used only as a metadata attachment point — no structural change to the rendered output.

## Security model

No data access changes. `usePathname()` is client-side only. Layout metadata is static. No new server-side logic.

## Known tradeoffs

- Per-route `layout.tsx` wrappers add a file per route. Acceptable given Next.js 15 App Router constraints — client page components cannot export `metadata`, so a server wrapper is required.
- Group detail pages (`/groups/[id]`) will show "Groups — Campfire" rather than the group name. Dynamic titles for detail pages are a separate enhancement.

Closes #266
Closes #267