### PR TITLE
fix(ux): people search disabled button + events date column width

### DIFF
--- a/src/app/(app)/events/page.tsx
+++ b/src/app/(app)/events/page.tsx
@@ -140,7 +140,7 @@ function GroupEvents({ groupId, groupName }: { groupId: string; groupName: strin
                       )}
                     </div>
                   ) : (
-                    <div className="w-12 shrink-0 flex items-center justify-center">
+                    <div className="w-16 shrink-0 flex items-center justify-center">
                       <span className="text-xs text-muted-foreground">TBD</span>
                     </div>
                   )}

--- a/src/app/(app)/people/page.tsx
+++ b/src/app/(app)/people/page.tsx
@@ -99,7 +99,7 @@ export default function PeoplePage() {
             onChange={(e) => setQuery(e.target.value)}
             className="max-w-sm"
           />
-          <Button type="submit" disabled={!query.trim()}>
+          <Button type="submit" disabled={!query.trim()} className="disabled:bg-muted disabled:text-muted-foreground disabled:opacity-100">
             Search
           </Button>
         </form>


### PR DESCRIPTION
## Summary

Two small polish fixes from the UX audit:

**#270 — People search button doesn't look disabled**
- `disabled:bg-muted disabled:text-muted-foreground disabled:opacity-100` added to the Search button in `people/page.tsx`
- The default `disabled:opacity-50` from shadcn's Button still applies the opacity class, but orange at 50% on a dark background was still visually prominent. Overriding to muted bg/text gives a clear visual signal that the button is inactive until a query is entered.

**#261 — Events date column width inconsistency**
- TBD column widened from `w-12` → `w-16` to match the confirmed-date column
- Prevents the event title and group columns from shifting position depending on whether an event has a confirmed date

## Security model

No auth changes. Both files are pure presentation — no queries or mutations added. All existing `protectedProcedure` guards are unchanged.

## Known tradeoffs

None. Both are single-line changes.

Closes #270, #261