### PR TITLE
feat(ux): layout proportions — right panel xl-only, wider list pages

### DIFF
--- a/src/app/(app)/events/page.tsx
+++ b/src/app/(app)/events/page.tsx
@@ -195,7 +195,7 @@ export default function EventsPage() {
 
   if (groupsLoading) {
     return (
-      <div className="max-w-2xl space-y-4">
+      <div className="max-w-3xl space-y-4">
         <h1 className="text-2xl font-bold">Events</h1>
         <GroupsListSkeleton count={3} />
       </div>
@@ -204,7 +204,7 @@ export default function EventsPage() {
 
   if (groups.length === 0) {
     return (
-      <div className="max-w-2xl space-y-4">
+      <div className="max-w-3xl space-y-4">
         <h1 className="text-2xl font-bold">Events</h1>
         <EmptyState
           icon={
@@ -222,7 +222,7 @@ export default function EventsPage() {
   }
 
   return (
-    <div className="max-w-2xl space-y-6">
+    <div className="max-w-3xl space-y-6">
       <h1 className="text-2xl font-bold">Events</h1>
 
       {/* Group tabs */}

--- a/src/app/(app)/feed/page.tsx
+++ b/src/app/(app)/feed/page.tsx
@@ -216,7 +216,7 @@ function FeedPageInner() {
   }
 
   return (
-    <div className="max-w-2xl mx-auto space-y-4">
+    <div className="max-w-3xl mx-auto space-y-4">
       {/* Invalidate all feed.list cache entries so the active tab refetches after a new post. */}
       <PostComposer onPosted={() => void utils.feed.list.invalidate()} />
 

--- a/src/app/(app)/friends/page.tsx
+++ b/src/app/(app)/friends/page.tsx
@@ -26,7 +26,7 @@ export default function FriendsPage() {
   const friends = data?.friends ?? [];
 
   return (
-    <div className="max-w-2xl space-y-6">
+    <div className="max-w-3xl space-y-6">
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold">Friends</h1>

--- a/src/app/(app)/groups/page.tsx
+++ b/src/app/(app)/groups/page.tsx
@@ -162,7 +162,7 @@ export default function GroupsPage() {
   const { data: myGroups = [], isLoading, refetch } = api.groups.list.useQuery();
 
   return (
-    <div className="max-w-2xl space-y-6">
+    <div className="max-w-3xl space-y-6">
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold">Groups</h1>

--- a/src/app/(app)/notifications/page.tsx
+++ b/src/app/(app)/notifications/page.tsx
@@ -90,7 +90,7 @@ export default function NotificationsPage() {
   const unreadCount = notifs.filter((n) => !n.readAt).length;
 
   return (
-    <div className="max-w-2xl mx-auto space-y-4">
+    <div className="max-w-3xl mx-auto space-y-4">
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold">Notifications</h1>

--- a/src/app/(app)/people/page.tsx
+++ b/src/app/(app)/people/page.tsx
@@ -44,7 +44,7 @@ export default function PeoplePage() {
   }
 
   return (
-    <div className="max-w-2xl space-y-8">
+    <div className="max-w-3xl space-y-8">
       <div>
         <h1 className="text-2xl font-bold">Find people</h1>
         <p className="text-muted-foreground">Search for friends by username or display name.</p>

--- a/src/components/nav/right-panel.tsx
+++ b/src/components/nav/right-panel.tsx
@@ -13,7 +13,7 @@ export function RightPanel() {
   if (hidden) return null;
 
   return (
-    <aside className="hidden lg:block w-60 shrink-0 sticky top-0 h-screen overflow-y-auto py-6 px-4 border-l">
+    <aside className="hidden xl:block w-56 shrink-0 sticky top-0 h-screen overflow-y-auto py-6 px-4 border-l">
       <UpcomingEventsPanel />
     </aside>
   );


### PR DESCRIPTION
## Summary

Addresses #275. Two changes to improve how the three-column layout fills the screen at common laptop widths (~1280px).

**Right panel breakpoint raised from `lg` to `xl`** (`src/components/nav/right-panel.tsx`):
- Before: right panel appears at 1024px+ — at 1024–1279px it crowds the centre column alongside the left panel
- After: right panel only appears at 1280px+ where there is genuine horizontal space for three columns
- Width also trimmed from `w-60` (240px) to `w-56` (224px) to leave more room for content at the boundary

**List page content widened from `max-w-2xl` to `max-w-3xl`** (feed, groups, friends, people, events, notifications):
- Before: 672px cap left visible empty margins in the centre column at wider viewports
- After: 768px cap fills the available space better without looking stretched

**Unchanged:**
- `src/app/(app)/layout.tsx` — shell `max-w-4xl` stays, needed by the settings two-column layout
- `src/app/(app)/profile/page.tsx` — single-entity view; `max-w-2xl` is intentional
- Left panel (`w-60`, `md:flex`) — no change
- Mobile layout — no change

## Security model

No auth/authz changes. Layout-only diff.

## Known tradeoffs

- `max-w-3xl` is 768px — post cards and friend list items at that width may feel slightly wide on some screens. Acceptable for MVP; can tune per-page if needed.
- Right panel hidden at 1024–1279px means users on 13" laptops never see upcoming events there. The events page itself is always reachable.

Closes #275