### PR TITLE
feat(games): instance-wide catalog search with ownership status (CAMP-085)

### DIFF
--- a/src/app/(app)/games/page.tsx
+++ b/src/app/(app)/games/page.tsx
@@ -321,6 +321,9 @@ function AddGameDialog({ onAdded }: { onAdded: () => void }) {
 function CatalogTab() {
   const [searchInput, setSearchInput] = useState("");
   const [search, setSearch] = useState("");
+  // Track in-flight add requests per game to avoid the shared isPending/variables
+  // race — clicking game A then game B before A resolves would re-enable A's button.
+  const [pendingIds, setPendingIds] = useState<Set<string>>(new Set());
   const utils = api.useUtils();
 
   useEffect(() => {
@@ -340,11 +343,20 @@ function CatalogTab() {
 
   // Insert-only mutation — safe for double-clicks; cannot accidentally remove a game.
   const addToLibrary = api.games.addToLibrary.useMutation({
-    onSuccess: () => {
+    onSuccess: (_data, variables) => {
+      setPendingIds((prev) => { const next = new Set(prev); next.delete(variables.gameId); return next; });
       void utils.games.catalog.invalidate();
       void utils.games.myGames.invalidate();
     },
+    onError: (_err, variables) => {
+      setPendingIds((prev) => { const next = new Set(prev); next.delete(variables.gameId); return next; });
+    },
   });
+
+  function handleAdd(gameId: string) {
+    setPendingIds((prev) => new Set(prev).add(gameId));
+    addToLibrary.mutate({ gameId, platform: "pc" });
+  }
 
   return (
     <div className="space-y-4">
@@ -417,12 +429,10 @@ function CatalogTab() {
                   {!g.owned && (
                     <button
                       className="text-xs text-primary hover:underline disabled:opacity-50"
-                      onClick={() => addToLibrary.mutate({ gameId: g.id, platform: "pc" })}
-                      disabled={addToLibrary.isPending && addToLibrary.variables?.gameId === g.id}
+                      onClick={() => handleAdd(g.id)}
+                      disabled={pendingIds.has(g.id)}
                     >
-                      {addToLibrary.isPending && addToLibrary.variables?.gameId === g.id
-                        ? "Adding…"
-                        : "+ Add to library"}
+                      {pendingIds.has(g.id) ? "Adding…" : "+ Add to library"}
                     </button>
                   )}
                 </div>
@@ -553,7 +563,11 @@ export default function GamesPage() {
         </button>
       </div>
 
-      {tab === "catalog" && <CatalogTab />}
+      {/* CatalogTab stays mounted to preserve search state and avoid re-firing the
+          unfiltered query on every tab switch. Hidden via CSS when not active. */}
+      <div className={tab === "catalog" ? undefined : "hidden"}>
+        <CatalogTab />
+      </div>
 
       {tab === "library" && (
       <>

--- a/src/server/trpc/routers/games.ts
+++ b/src/server/trpc/routers/games.ts
@@ -218,7 +218,9 @@ export const gamesRouter = createTRPCRouter({
           platform: input.platform,
           source: "manual",
         })
-        .onConflictDoNothing();
+        // Specify conflict target explicitly so only the PK violation is silenced.
+        // gameOwnerships PK is (userId, gameId, platform).
+        .onConflictDoNothing({ target: [gameOwnerships.userId, gameOwnerships.gameId, gameOwnerships.platform] });
 
       return { owned: true };
     }),


### PR DESCRIPTION
## Summary

- Adds a **Browse Catalog** tab to `/games` that searches all games in the instance database (not just the user's own library)
- New `games.catalog` tRPC procedure with cursor pagination, optional title search, and per-game ownership status for the current user
- Each catalog card shows an **Owned** badge if the user already has the game, or an **+ Add to library** CTA that inserts a `gameOwnerships` row (PC platform, manual source)

## Changes

### `src/server/trpc/routers/games.ts`
- New `catalog` procedure: cursor-based pagination (`asc(games.id)`), `ilike` title search with LIKE metachar escaping, stable total count (cursor-excluded), `owned` flag resolved in a single batched `IN` query against `gameOwnerships`
- Rate-limited at 30 req/min per user via `assertRateLimit`

### `src/app/(app)/games/page.tsx`
- Page heading renamed "Games"; tab switcher added (My Library / Browse Catalog)
- `CatalogTab` component: 6-column cover grid, debounced search, skeleton loading, empty state, load-more pagination
- View mode toggle + Add Game button conditionally shown only in My Library tab
- Library game count relocated below filter row

## Security model

- `catalog` is behind `protectedProcedure` — unauthenticated users cannot browse the catalog
- Ownership check is scoped to `ctx.user.id` — no user can see another user's ownership status from this procedure
- Input is validated with Zod; title search uses parameterised `ilike` — no raw SQL interpolation
- Rate limit: `assertRateLimit` at 30/min per user to prevent catalog scraping

## Known tradeoffs

- **Add to library defaults to PC platform.** The CTA is a one-click convenience; users who own the game on a different platform can update it from the game detail page. This matches the existing `toggleOwnership` mutation which already defaults to PC in the add-game dialog.
- **Total count is cursor-independent.** The `count` query excludes the cursor filter so the total stays stable across load-more pages. This is intentional and matches the `myGames` pattern.
- **Catalog is unbounded at MVP scale.** The cursor limit (max 50/page) keeps individual queries small, but there is no index on `games.id` other than the PK. Acceptable at MVP scale.

## Test plan

- [ ] Browse Catalog tab loads and shows game covers
- [ ] Search filters results in real time (debounced)
- [ ] Owned games show "Owned" badge; unowned show "+ Add to library"
- [ ] "+ Add to library" adds the game and immediately shows "Owned" badge
- [ ] Load more paginates correctly
- [ ] My Library tab still works with all filters, search, view modes
- [ ] Unauthenticated access returns 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)