### PR TITLE
feat(onboarding): skippable Steam account link step (CAMP-144)

### DIFF
--- a/src/app/(app)/onboarding/page.tsx
+++ b/src/app/(app)/onboarding/page.tsx
@@ -3,6 +3,7 @@
 import { Suspense, useRef, useState, useEffect } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Image from "next/image";
+import { CheckCircle2 } from "lucide-react";
 import { api } from "@/trpc/react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -392,9 +393,7 @@ function StepSteam({ onDone, justLinked }: { onDone: () => void; justLinked: boo
       <CardContent className="space-y-4">
         {justLinked ? (
           <div className="flex items-center gap-2 rounded-md bg-green-500/10 px-3 py-2 text-sm text-green-700 dark:text-green-400">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-              <polyline points="20 6 9 17 4 12" />
-            </svg>
+            <CheckCircle2 className="h-4 w-4 shrink-0" aria-hidden="true" />
             Steam account connected!
           </div>
         ) : (
@@ -414,7 +413,7 @@ function StepSteam({ onDone, justLinked }: { onDone: () => void; justLinked: boo
               Skip
             </Button>
             <Button asChild className="flex-1">
-              <a href="/api/steam/connect?return_to=/onboarding%3Fstep%3Dsteam">
+              <a href="/api/steam/connect?return_to=/onboarding">
                 Connect Steam
               </a>
             </Button>
@@ -442,18 +441,19 @@ function OnboardingContent() {
   const searchParams = useSearchParams();
   const [step, setStep] = useState<Step>("username");
 
-  // When Steam OAuth redirects back with ?step=steam&steam_linked=1, jump to the steam step.
+  // When Steam OAuth redirects back with ?steam_linked=1, jump to the steam step.
+  // This fires once on mount (or when the param appears after a full-page redirect).
+  const steamLinked = searchParams.get("steam_linked") === "1";
   useEffect(() => {
-    if (searchParams.get("step") === "steam") {
+    if (steamLinked) {
       setStep("steam");
     }
-  }, [searchParams]);
+  }, [steamLinked]);
 
   // Fetch current user to pre-fill the display name in step 2
   const { data: me } = api.user.me.useQuery();
 
   const stepIndex = STEPS.indexOf(step);
-  const justLinked = searchParams.get("steam_linked") === "1";
 
   function next() {
     const nextStep = STEPS[stepIndex + 1];
@@ -499,7 +499,7 @@ function OnboardingContent() {
         <p className="text-sm text-muted-foreground">Loading…</p>
       )}
       {step === "invite" && <StepInvite onDone={next} />}
-      {step === "steam" && <StepSteam onDone={next} justLinked={justLinked} />}
+      {step === "steam" && <StepSteam onDone={next} justLinked={steamLinked} />}
     </div>
   );
 }

--- a/src/app/api/steam/callback/route.ts
+++ b/src/app/api/steam/callback/route.ts
@@ -31,12 +31,23 @@ export async function GET(req: NextRequest) {
 
   const { searchParams } = req.nextUrl;
 
-  // resolve the post-link redirect destination.
-  // return_to must be a relative path to prevent open-redirect attacks.
+  // Resolve the post-link redirect destination.
+  // Parse with URL to normalise encoding, then accept only the pathname so
+  // no attacker-controlled query params or fragments flow into the success URL.
+  // Fall back to /settings if absent, malformed, or from a different origin.
   const returnToParam = searchParams.get("return_to") ?? "";
-  const isRelativePath = /^\/[^/]/.test(returnToParam) || returnToParam === "/";
-  const postLinkPath = isRelativePath ? returnToParam : "/settings";
-  const postLinkUrl = new URL(postLinkPath, env.NEXT_PUBLIC_APP_URL);
+  let postLinkPathname = "/settings";
+  if (returnToParam) {
+    try {
+      const resolved = new URL(returnToParam, env.NEXT_PUBLIC_APP_URL);
+      if (resolved.origin === env.NEXT_PUBLIC_APP_URL) {
+        postLinkPathname = resolved.pathname;
+      }
+    } catch {
+      // Malformed — fall back to /settings.
+    }
+  }
+  const postLinkUrl = new URL(postLinkPathname, env.NEXT_PUBLIC_APP_URL);
 
   // Default error redirect is always /settings to avoid leaking error codes to caller-controlled URLs
   const settingsUrl = new URL("/settings", env.NEXT_PUBLIC_APP_URL);

--- a/src/app/api/steam/connect/route.ts
+++ b/src/app/api/steam/connect/route.ts
@@ -23,10 +23,23 @@ export async function GET(req: NextRequest) {
     return NextResponse.redirect(new URL("/login", env.NEXT_PUBLIC_APP_URL));
   }
 
-  // Pass an optional return_to through the callback as a query param.
-  const returnTo = req.nextUrl.searchParams.get("return_to") ?? "";
+  // Pass an optional return_to through the callback.
+  // Validate here (defence-in-depth): extract only the pathname from user input,
+  // discarding any query/hash so the callback receives a clean relative path.
+  const returnToRaw = req.nextUrl.searchParams.get("return_to") ?? "";
   const callbackUrl = new URL(`${env.NEXT_PUBLIC_APP_URL}/api/steam/callback`);
-  if (returnTo) callbackUrl.searchParams.set("return_to", returnTo);
+  if (returnToRaw) {
+    try {
+      // Resolve against app origin so relative paths work; then take only pathname.
+      const resolved = new URL(returnToRaw, env.NEXT_PUBLIC_APP_URL);
+      // Only accept paths that belong to our own origin.
+      if (resolved.origin === env.NEXT_PUBLIC_APP_URL) {
+        callbackUrl.searchParams.set("return_to", resolved.pathname);
+      }
+    } catch {
+      // Malformed URL — ignore; callback will fall back to /settings.
+    }
+  }
 
   const params = new URLSearchParams({
     "openid.ns": "http://specs.openid.net/auth/2.0",


### PR DESCRIPTION
## Summary

- Adds a fourth onboarding step (after Invite) prompting new users to connect their Steam account before going to the feed
- Fully skippable — a "Skip" button is always visible; no Steam connection is required to proceed
- After Steam OAuth completes, the callback redirects back to the onboarding page with `?steam_linked=1`; the page detects this and jumps to the Steam step showing a success confirmation

## How it works

1. User reaches Step 4 (Steam) via normal onboarding progression
2. "Connect Steam" links to `/api/steam/connect?return_to=/onboarding`
3. User completes Steam OpenID flow; callback redirects to `/onboarding?steam_linked=1`
4. `useSearchParams` detects `steam_linked=1` → `useEffect` sets step to `"steam"` with the success confirmation
5. User clicks "Continue" → proceeds to `/feed`

## Changes

### `src/app/(app)/onboarding/page.tsx`
- Added `StepSteam` card with "Connect Steam" CTA and "Skip" button; success state shows `<CheckCircle2>` from lucide-react
- STEPS array extended: `["username", "profile", "invite", "steam"]`
- Progress indicator updates automatically (4 steps total)
- `useSearchParams` isolated in `OnboardingContent`, wrapped in `<Suspense>` per Next.js App Router requirement
- `useEffect` depends on derived `steamLinked` boolean (not searchParams reference) to avoid spurious re-runs

### `src/app/api/steam/connect/route.ts`
- Accepts optional `return_to` query param; validates with `new URL` + origin check, extracts only `pathname`
- Clean pathname is forwarded to the callback URL as `?return_to=<pathname>`

### `src/app/api/steam/callback/route.ts`
- Reads `return_to` from the callback query params
- Validates with `new URL` + origin check, extracts only `pathname` — discards all query/hash from user input
- Falls back to `/settings` if absent, malformed, or different origin
- Error redirects always go to `/settings` regardless of `return_to`
- Success redirect: `<return_to pathname>?steam_linked=1`
- **OpenID return_to validation (unchanged)**: the existing `startsWith(expectedReturnTo)` check compares against the base callback path without query string — this still passes correctly when the callback URL carries `?return_to=...`

## Security model

- **Open-redirect protection**: both routes parse `return_to` with `new URL`, confirm `origin === NEXT_PUBLIC_APP_URL`, and extract only `pathname`. All query params, fragments, `//`-relative URLs, encoded separators, and backslash variants are rejected or stripped.
- **Pathname-only in success redirect**: query params from the caller are never carried into the success URL. Only our own `steam_linked=1` is appended.
- **Error redirect always to `/settings`**: error codes never reach caller-controlled destinations.
- **Authentication guard unchanged**: both routes require an active session.
- **OpenID return_to check unchanged**: `startsWith` against the base callback path; continues to work with or without `?return_to=...` on the callback URL.

## Known tradeoffs

- **Users with Steam already linked see the step anyway.** They can skip it. A future improvement would check `me.steamId` and skip the step automatically. Minor UX gap, not blocking MVP.

## Test plan

- [ ] New user completes username → profile → invite → Steam steps in order
- [ ] Skip on Steam step lands on /feed
- [ ] "Connect Steam" initiates Steam OAuth; successful link returns to `/onboarding?steam_linked=1` showing success confirmation
- [ ] "Continue" after success lands on /feed
- [ ] Steam OAuth error redirects to `/settings?steam_error=...` (not back to onboarding)
- [ ] Existing `/api/steam/connect` with no `return_to` still works (redirects to /settings after linking)
- [ ] `return_to=//evil.com` and `return_to=https://evil.com/path` both fall back to /settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)