### PR TITLE
fix(games): invalidate catalog cache after AddGameDialog toggleOwnership

### DIFF
--- a/src/app/(app)/games/page.tsx
+++ b/src/app/(app)/games/page.tsx
@@ -69,10 +69,15 @@ function AddGameDialog({ onAdded }: { onAdded: () => void }) {
     onError: (err) => setError(err.message),
   });
 
+  const utils = api.useUtils();
+
   const toggleOwnership = api.games.toggleOwnership.useMutation({
     onSuccess: () => {
       setOpen(false);
       reset();
+      // Invalidate both caches so the catalog 'Owned' badge reflects the new
+      // ownership immediately without needing a manual refetch (CAMP-288).
+      void utils.games.catalog.invalidate();
       onAdded();
     },
     onError: (err) => setError(err.message),


### PR DESCRIPTION
## Summary

Closes #288 — catalog 'Owned' badge can be stale after add from game detail page

## Problem

When a user added a game via the Add Game dialog (IGDB import or manual add → platform confirm), `toggleOwnership.onSuccess` only called `onAdded()`, which invalidates `myGames`. The catalog query (`games.catalog`) was not invalidated, so the 'Owned' badge remained stale until the next page interaction triggered a refetch.

## Fix

Added `void utils.games.catalog.invalidate()` inside `AddGameDialog`'s `toggleOwnership.onSuccess` handler, alongside the existing `onAdded()` call. `AddGameDialog` now holds its own `utils` reference for this purpose.

The `CatalogTab.addToLibrary` mutation (the one-click "+ Add to library" button in the catalog itself) already invalidated both caches correctly — this fix closes the gap for the dialog path.

## Security model

No auth or data changes. This is a client-side cache invalidation only. All mutations are behind `protectedProcedure`; no files outside the diff affect security.

## Known tradeoffs

None. `catalog.invalidate()` fires an in-background refetch; it does not block the UI.