### PR TITLE
fix(push): add server-only guard to prevent web-push bundling in browser

### DIFF
--- a/src/server/push.ts
+++ b/src/server/push.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import webpush from "web-push";
 import { env } from "@/env";
 import { logger } from "@/lib/logger";


### PR DESCRIPTION
## Summary

**Bug:** `Module not found: Can't resolve 'web-push'` build error on the feed page.

**Root cause:** `src/server/push.ts` imports `web-push`, a Node.js-only package. Without a `server-only` boundary, Next.js Turbopack includes the file in the App Router client bundle and fails to resolve the native Node.js modules that `web-push` depends on.

**Fix:** Added `import "server-only"` at the top of `src/server/push.ts`. This causes Next.js to throw a clear build-time error if the module is ever imported from a client component or edge route, preventing the silent bundle inclusion.

## Security model

No auth/data changes. `src/server/push.ts` is only ever called from:
- `src/server/jobs/push-jobs.ts` (server-side queue helper)
- `src/worker/processors/push.ts` (BullMQ worker, Node.js process)
- `src/server/trpc/routers/notifications.ts` (tRPC protected procedure)

All are server-only contexts. The `server-only` import is the correct enforcement mechanism here.

## Known tradeoffs

None.