### PR TITLE
fix(games): use sql.param for SteamSpy JSONB merge

### DIFF
--- a/src/server/lib/steamspy.ts
+++ b/src/server/lib/steamspy.ts
@@ -68,10 +68,13 @@ export async function snapshotSteamSpyData(gameId: string, steamAppId: string): 
 
   // Atomic jsonb merge — preserves existing keys (e.g. IGDB data) without a read-then-write race.
   // COALESCE handles the case where metadataJson is currently NULL.
+  // sql.param() sends the JSON as a bound parameter rather than interpolating it
+  // into the SQL text, guarding against unexpected characters in API responses.
+  const steamspyJsonParam = sql.param(JSON.stringify({ steamspy: steamspyData }));
   await db
     .update(games)
     .set({
-      metadataJson: sql`COALESCE(${games.metadataJson}, '{}'::jsonb) || ${JSON.stringify({ steamspy: steamspyData })}::jsonb`,
+      metadataJson: sql`COALESCE(${games.metadataJson}, '{}'::jsonb) || ${steamspyJsonParam}::jsonb`,
     })
     .where(eq(games.id, gameId));
 }


### PR DESCRIPTION
## Summary

Closes #302 — tech-debt: steamspy.ts uses raw JSON.stringify interpolation in sql template.

Same fix as was applied to `igdb.ts` in PR #301: replaces raw `JSON.stringify(...)` interpolation in the Drizzle `sql` tagged template with `sql.param(...)` so the JSON string is sent as a bound parameter rather than literal SQL text.

## Change

One-line extraction before the `db.update()` call in `snapshotSteamSpyData`:

```ts
// Before
metadataJson: sql`COALESCE(${games.metadataJson}, '{}') || ${JSON.stringify({ steamspy })}::jsonb`

// After
const steamspyJsonParam = sql.param(JSON.stringify({ steamspy: steamspyData }));
metadataJson: sql`COALESCE(${games.metadataJson}, '{}') || ${steamspyJsonParam}::jsonb`
```

## Security model

`snapshotSteamSpyData` is called from:
- `importFromIgdb` tRPC procedure (server-side, fire-and-forget)
- `upsertBatch` in `steam.ts` (worker process, fire-and-forget)

Both are server-only contexts. The SteamSpy response is an external API response — using a bound parameter is the correct approach regardless of trust level.

## Known tradeoffs

None.