### PR TITLE
feat(feed): hot feed ranking — HN-style engagement-weighted sort (CAMP-098)

### DIFF
--- a/src/app/(app)/feed/page.tsx
+++ b/src/app/(app)/feed/page.tsx
@@ -177,7 +177,8 @@ function FeedList({
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, refetch } =
     api.feed.list.useInfiniteQuery(
       { limit: 20, filter, sort },
-      { getNextPageParam: (lastPage) => lastPage.nextCursor }
+      // Hot sort never paginates — always returns top 50 with no cursor.
+      { getNextPageParam: (lastPage) => sort === "new" ? lastPage.nextCursor : undefined }
     );
 
   const allItems = data?.pages.flatMap((p) => p.items) ?? [];

--- a/src/server/trpc/routers/feed.ts
+++ b/src/server/trpc/routers/feed.ts
@@ -133,11 +133,16 @@ export const feedRouter = createTRPCRouter({
       if (input.sort === "hot") {
         const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
 
-        // Step 1: candidate post IDs within the visibility window
+        // Step 1: candidate post IDs within the visibility window.
+        // Capped at 1000 most-recent to avoid unbounded IN-list parameters downstream.
+        // Hot scoring over the 1000 most-recent visible posts is a good-enough approximation
+        // at MVP scale; truly viral older posts naturally decay below newer ones anyway.
         const candidateRows = await db
           .select({ id: posts.id, createdAt: posts.createdAt })
           .from(posts)
-          .where(and(isNull(posts.deletedAt), visibilityFilter, gt(posts.createdAt, thirtyDaysAgo)));
+          .where(and(isNull(posts.deletedAt), visibilityFilter, gt(posts.createdAt, thirtyDaysAgo)))
+          .orderBy(desc(posts.createdAt))
+          .limit(1000);
 
         if (candidateRows.length === 0) return { items: [], nextCursor: undefined };
 
@@ -179,6 +184,7 @@ export const feedRouter = createTRPCRouter({
           .slice(0, 50);
 
         const topIds = scored.map((r) => r.id);
+        if (topIds.length === 0) return { items: [], nextCursor: undefined };
 
         const hotPosts = await db.query.posts.findMany({
           where: inArray(posts.id, topIds),


### PR DESCRIPTION
## Summary

- Adds a **New / Hot** sort toggle to the feed (top-right of the filter bar)
- **Hot** ranks posts using an HN-style time-decayed engagement score: `(reactions + comments×2) / (age_hours + 2)^1.5`
- Returns the top 50 posts from the last 30 days, no cursor pagination
- **New** (default) is completely unchanged — existing chronological cursor pagination
- Sort state persisted in `?sort=hot` URL param; back/forward navigation restores it
- `FeedList` keyed by `filter:sort` so each combination has an independent query

## Implementation

**`feed.list` tRPC procedure** — new `sort: z.enum(["new","hot"]).default("new")` input:
- `sort=hot` path: 3 queries — (1) candidate IDs via visibility filter, (2) reaction counts grouped by post, (3) comment counts grouped by post. Scored + sorted in JS, then top 50 re-fetched with full relations via `findMany`. No raw SQL — all Drizzle query builder.
- `sort=new` path: unchanged. Cursor only parsed when `sort=new`.

**`feed/page.tsx`**:
- `handleSort` updates local state + URL param
- New/Hot pill toggle rendered to the right of the filter tabs
- "Load more" button hidden when `sort=hot` (no next cursor)

## Security model

- `protectedProcedure` — caller must be authenticated (enforced by tRPC middleware in `src/server/trpc/trpc.ts`)
- Visibility filter is identical for both sort paths — friends/groups/block exclusion applied before scoring
- No user-controlled input interpolated into SQL; engagement counts use parameterised Drizzle queries

## Known tradeoffs

- Hot path does 3 DB round-trips instead of 1. At MVP scale (small friend groups, tens of posts) this is negligible. A single aggregating SQL query could be used if performance becomes a concern.
- Candidate window is 30 days and max 50 results. Very active feeds with >50 posts in 30 days will have candidates scored correctly but at most 50 are returned.
- Hot scores are computed in JS at request time — no denormalised score column. Simple to reason about; no background job needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)