### PR TITLE
fix(push): lazy-require web-push to prevent bundler resolution failure

### DIFF
--- a/src/server/push.ts
+++ b/src/server/push.ts
@@ -55,7 +55,7 @@ export async function sendPush(
   }
 
   if (!_webpush) {
-    log.warn("sendPush called but web-push not loaded — skipping");
+    log.warn("sendPush called but web-push not initialised — VAPID env vars may be missing");
     return { ok: false, expired: false };
   }
   try {


### PR DESCRIPTION
## Summary

`import webpush from "web-push"` at the module top level causes Next.js/Turbopack to statically include the Node.js native module in the tRPC route bundle, producing a build error even though `push.ts` already has `import "server-only"`.

Root cause: `server-only` is a **runtime** guard (throws when executed in a browser context). It does not affect the **bundler's** static import graph. Turbopack still follows the import chain: `notifications.ts` → `push.ts` → `web-push` and attempts to bundle a Node.js native module for the App Router route.

Fix: replace the top-level `import` with a `require("web-push")` call inside `configure()`, which is only ever called from `sendPush()`. The bundler does not statically trace `require()` calls, so `web-push` is never included in the route bundle. The `server-only` import is retained as a defence-in-depth runtime guard.

## Security model

No auth/authz changes. `sendPush` is only called from the BullMQ push worker (`src/worker/processors/push.ts`), which runs server-side. `isPushEnabled()` (used in the notifications router) only reads env vars — no web-push code path.

## Known tradeoffs

`require()` loses static type safety for the `webpush` variable. Mitigated by typing it as `typeof import("web-push")` which gives full IntelliSense/type-checking at the call site without triggering the bundler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)