### PR TITLE
feat(feed): post permalink page + notification links (CAMP-164)

### DIFF
--- a/src/app/(app)/feed/[postId]/page.tsx
+++ b/src/app/(app)/feed/[postId]/page.tsx
@@ -8,12 +8,12 @@ import { FeedSkeleton } from "@/components/ui/skeletons";
 
 export default function PostPermalinkPage({ params }: { params: Promise<{ postId: string }> }) {
   const { postId } = use(params);
-  const { data: me } = api.user.me.useQuery();
-  const { data: post, isLoading, refetch } = api.feed.getPost.useQuery({ id: postId });
+  const { data: me, isLoading: meLoading } = api.user.me.useQuery();
+  const { data: post, isLoading: postLoading, refetch } = api.feed.getPost.useQuery({ id: postId });
 
-  if (isLoading || !me) return <FeedSkeleton />;
+  if (postLoading || meLoading) return <FeedSkeleton />;
 
-  if (post === null || post === undefined) {
+  if (!post || !me) {
     return (
       <div className="max-w-2xl mx-auto space-y-4">
         <Link href="/feed" className="text-sm text-muted-foreground hover:text-foreground">

--- a/src/app/(app)/notifications/page.tsx
+++ b/src/app/(app)/notifications/page.tsx
@@ -44,7 +44,6 @@ function notifLink(type: string, data: NotifData): string | null {
   switch (type) {
     case "post_comment":
     case "post_like":
-      return data.postId ? `/feed/${data.postId}` : "/feed";
     case "comment_like":
       return data.postId ? `/feed/${data.postId}` : "/feed";
     case "group_invite_received":

--- a/src/server/trpc/routers/feed.ts
+++ b/src/server/trpc/routers/feed.ts
@@ -449,7 +449,7 @@ export const feedRouter = createTRPCRouter({
       // Fire-and-forget: a notification failure must not roll back the comment insert.
       // commenterName is denormalised at creation time — reflects the name at the time of the comment.
       if (post.authorId !== ctx.user.id) {
-        db.insert(notifications).values({
+        void db.insert(notifications).values({
           id: createId(),
           userId: post.authorId,
           type: "post_comment",
@@ -604,7 +604,7 @@ export const feedRouter = createTRPCRouter({
           columns: { authorId: true },
         });
         if (post && post.authorId !== ctx.user.id) {
-          db.insert(notifications).values({
+          void db.insert(notifications).values({
             id: createId(),
             userId: post.authorId,
             type: "post_like",
@@ -622,7 +622,7 @@ export const feedRouter = createTRPCRouter({
           columns: { authorId: true, postId: true },
         });
         if (comment && comment.authorId !== ctx.user.id) {
-          db.insert(notifications).values({
+          void db.insert(notifications).values({
             id: createId(),
             userId: comment.authorId,
             type: "comment_like",


### PR DESCRIPTION
## Summary
- Adds `/feed/[postId]` — a direct URL for a single post with its full comment thread
- Notification messages for `post_comment`, `post_like`, `comment_like` now link directly to the post permalink
- Push notification `url` field updated from `/feed` to `/feed/{postId}` so tapping a push notification opens the correct post

## Changes

### `feed.getPost` tRPC procedure (`src/server/trpc/routers/feed.ts`)
New `getPost` query input `{ id: string }`. Returns the full post with relations (author, group, event, reactions, comments), or `null` if the post doesn't exist, is soft-deleted, or the caller lacks visibility.

**Visibility rules** (same as `feed.list`):
1. Own post — always visible.
2. Group post — caller must be a `groupMemberships` member of that group.
3. Non-group post — caller must have an `accepted` `friendships` record with the author.

### Post permalink page (`src/app/(app)/feed/[postId]/page.tsx`)
Client component. Renders a single `PostCard` + "← Back to feed" link. Shows an access-denied message (not a 404, to avoid leaking existence) when `getPost` returns `null`.

### `comment_like` notification now includes `postId`
The `toggleLike` mutation for `commentId` now fetches both `authorId` and `postId` from the comment row (one SELECT, was already needed for authorId). `postId` is stored in `data` jsonb and used for both the push URL and the notification link.

### Notifications page (`src/app/(app)/notifications/page.tsx`)
Added `notifLink()` helper that maps notification type → client-side URL. `post_comment`, `post_like`, `comment_like` → `/feed/{postId}`. `group_invite_received` → `/groups`. `friend_request_received` / `friend_request_accepted` → no link (handled inline by Accept/Decline buttons). Messages wrapped in `<Link>` when a URL is available.

## Security model
- `getPost` is behind `protectedProcedure` — must be authenticated.
- Visibility check runs server-side before returning data — group membership and friendship verified against the DB.
- `null` is returned for not-found and access-denied uniformly — no information leakage.
- `postId` stored in notification `data` is taken from the DB record (`post.id` / `comment.postId`), never from user input.

## Known tradeoffs
- No scroll-to-comment on the permalink (would require a URL fragment + ref forwarding in PostCard). `/feed/{postId}` is sufficient for MVP — the full comment thread is visible on load.
- The permalink page shows only the single post with no surrounding feed context. A "view in feed" link at the bottom would be a nice future addition.