### PR TITLE
feat(events): Add to Calendar (.ics export) on confirmed events (CAMP-167)

### DIFF
--- a/src/app/(app)/events/[id]/page.tsx
+++ b/src/app/(app)/events/[id]/page.tsx
@@ -541,7 +541,8 @@ function downloadIcs(event: {
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
   a.href = url;
-  a.download = `${event.title.replace(/[^a-z0-9]/gi, "-").toLowerCase()}.ics`;
+  const safeName = event.title.replace(/[^a-z0-9]/gi, "-").toLowerCase().replace(/^-+|-+$/g, "") || "event";
+  a.download = `${safeName}.ics`;
   a.click();
   // Defer revoke so the browser's async download handler has time to read the blob.
   setTimeout(() => URL.revokeObjectURL(url), 60_000);


### PR DESCRIPTION
## Summary

- Adds an **Add to Calendar** link next to the confirmed time on event detail pages.
- Generates a standard RFC 5545 iCalendar (`.ics`) file entirely client-side — no external API, no new dependency.
- Downloaded `.ics` files open in Google Calendar, Outlook, Apple Calendar, and any other iCalendar-compatible app.
- Button only renders when `event.confirmedStartsAt` is set (i.e. the event has been confirmed).
- Default end time: 2 hours after start when `confirmedEndsAt` is not set.

## Security model

- Pure client-side operation (Blob + URL.createObjectURL). No server data sent anywhere.
- No new tRPC routes or DB access. The event data is already loaded by the existing `events.get` query, which is behind `protectedProcedure` + group membership check (in `src/server/trpc/routers/events.ts`).

## Known tradeoffs

- UID in the VEVENT is `Date.now()@projectcampfire` — not stable across downloads. If a user downloads twice and imports both, their calendar may show a duplicate. This is acceptable for MVP; a stable UID (e.g. based on `event.id`) could be added later.
- Time is exported in UTC. Users whose calendar app doesn't auto-convert to local timezone may see the wrong time. This is standard iCalendar behaviour — all major calendar apps handle UTC correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)