### PR TITLE
feat(friends): pending request badge on Friends nav link (CAMP-168)

### DIFF
--- a/src/components/nav/profile-card.tsx
+++ b/src/components/nav/profile-card.tsx
@@ -189,7 +189,7 @@ export function ProfileCard({
         <div className="flex flex-col gap-1">
           {stats ? (
             <>
-              <StatRow href="/friends" label="Friends" count={stats.friendCount} active={isActive("/friends")} onClick={onNavigate} />
+              <StatRow href="/friends" label="Friends" count={stats.friendCount} active={isActive("/friends")} pendingCount={stats.pendingRequestCount} onClick={onNavigate} />
               <StatRow href="/groups"  label="Groups"  count={stats.groupCount}  active={isActive("/groups")}  onClick={onNavigate} />
               <StatRow href="/games"   label="Games"   count={stats.gameCount}   active={isActive("/games")}   onClick={onNavigate} />
             </>
@@ -259,12 +259,14 @@ function StatRow({
   label,
   count,
   active,
+  pendingCount,
   onClick,
 }: {
   href: string;
   label: string;
   count: number;
   active: boolean;
+  pendingCount?: number;
   onClick?: () => void;
 }) {
   return (
@@ -278,7 +280,12 @@ function StatRow({
       }`}
     >
       <span className={active ? "font-semibold" : "font-medium"}>{label}</span>
-      <span className="flex items-center gap-1 tabular-nums">
+      <span className="flex items-center gap-1.5 tabular-nums">
+        {pendingCount ? (
+          <span className="inline-flex items-center justify-center rounded-full bg-destructive text-destructive-foreground text-[9px] font-bold h-3.5 min-w-3.5 px-0.5">
+            {pendingCount > 9 ? "9+" : pendingCount}
+          </span>
+        ) : null}
         {count}
         <span className={`transition-opacity text-[10px] ${active ? "opacity-60" : "opacity-0 group-hover:opacity-60"}`}>→</span>
       </span>

--- a/src/server/trpc/routers/user.ts
+++ b/src/server/trpc/routers/user.ts
@@ -236,14 +236,19 @@ export const userRouter = createTRPCRouter({
   // Lightweight counts for the feed profile sidebar
   profileStats: protectedProcedure.query(async ({ ctx }) => {
     const userId = ctx.user.id;
-    const [friendCount, groupCount, gameCount] = await Promise.all([
+    const [friendCount, groupCount, gameCount, pendingRequestCount] = await Promise.all([
       db.$count(friendships, and(
         eq(friendships.status, "accepted"),
         sql`(${friendships.requesterId} = ${userId} OR ${friendships.addresseeId} = ${userId})`
       )),
       db.$count(groupMemberships, eq(groupMemberships.userId, userId)),
       db.$count(gameOwnerships, and(eq(gameOwnerships.userId, userId), eq(gameOwnerships.hidden, false))),
+      // Incoming pending friend requests — shown as a badge on the Friends nav link.
+      db.$count(friendships, and(
+        eq(friendships.addresseeId, userId),
+        eq(friendships.status, "pending")
+      )),
     ]);
-    return { friendCount, groupCount, gameCount };
+    return { friendCount, groupCount, gameCount, pendingRequestCount };
   }),
 });


### PR DESCRIPTION
## Summary

- Shows the count of incoming pending friend requests as a red badge on the **Friends** stat row in the desktop left panel.
- Badge auto-updates via the existing `profileStats` query refetch cycle.
- `pendingRequestCount` added to `user.profileStats` — one extra `$count` query, runs in parallel with the existing three counts.
- Badge style matches the existing notification bell badge (destructive red, 9+ cap).

## Security model

- `profileStats` is behind `protectedProcedure`. The `pendingRequestCount` query is `WHERE addresseeId = ctx.user.id AND status = 'pending'` — counts only requests addressed to the caller, not all pending requests.

## Known tradeoffs

- `profileStats` is polled every time the component mounts (no explicit polling interval configured there, unlike `unreadCount`). The pending count will update when the page re-focuses/re-mounts, not on a fixed interval. Acceptable for MVP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)