### PR TITLE
fix(ux): suppress right panel until events data confirmed present

### DIFF
--- a/src/components/feed/upcoming-events-panel.tsx
+++ b/src/components/feed/upcoming-events-panel.tsx
@@ -2,9 +2,7 @@
 
 import Link from "next/link";
 import { CalendarDays } from "lucide-react";
-import { Skeleton } from "@/components/ui/skeleton";
 import { Badge } from "@/components/ui/badge";
-
 import type { RouterOutputs } from "@/trpc/react";
 
 type UpcomingEvent = RouterOutputs["events"]["upcoming"][number];
@@ -28,13 +26,7 @@ const RSVP_LABELS: Record<string, string> = {
   maybe: "Maybe",
 };
 
-export function UpcomingEventsPanel({
-  upcoming,
-  isLoading,
-}: {
-  upcoming: UpcomingEvent[] | undefined;
-  isLoading: boolean;
-}) {
+export function UpcomingEventsPanel({ upcoming }: { upcoming: UpcomingEvent[] }) {
   return (
     <aside className="flex flex-col gap-3">
       <div className="rounded-xl border bg-card p-4">
@@ -43,73 +35,58 @@ export function UpcomingEventsPanel({
           Upcoming events
         </h2>
 
-        {isLoading && (
-          <div className="flex flex-col gap-3">
-            {[0, 1, 2].map((i) => (
-              <div key={i} className="flex flex-col gap-1.5">
-                <Skeleton className="h-3.5 w-3/4" />
-                <Skeleton className="h-3 w-1/2" />
-              </div>
-            ))}
-          </div>
-        )}
+        <div className="flex flex-col divide-y">
+          {upcoming.map((event) => {
+            const dateLabel = formatEventDate(event.confirmedStartsAt);
+            const isImminent = dateLabel === "Today";
+            const myRsvp = event.rsvps[0]?.status;
 
-        {upcoming && upcoming.length > 0 && (
-          <div className="flex flex-col divide-y">
-            {upcoming.map((event) => {
-              const dateLabel = formatEventDate(event.confirmedStartsAt);
-              const isImminent = dateLabel === "Today";
-              const myRsvp = event.rsvps[0]?.status;
+            return (
+              <Link
+                key={event.id}
+                href={`/events/${event.id}`}
+                className="flex flex-col gap-1 py-2.5 first:pt-0 last:pb-0 group"
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <p className="text-sm font-medium leading-tight group-hover:text-primary transition-colors line-clamp-2">
+                    {event.title}
+                  </p>
+                  {isImminent && (
+                    <Badge variant="outline" className="text-[10px] shrink-0 border-primary text-primary">
+                      Today
+                    </Badge>
+                  )}
+                </div>
+                <div className="flex items-center gap-1.5 flex-wrap">
+                  <span className="text-xs text-muted-foreground truncate">
+                    {event.group.name}
+                  </span>
+                  {dateLabel && !isImminent && (
+                    <>
+                      <span className="text-xs text-muted-foreground">·</span>
+                      <span className="text-xs text-muted-foreground">{dateLabel}</span>
+                    </>
+                  )}
+                  {myRsvp && (
+                    <>
+                      <span className="text-xs text-muted-foreground">·</span>
+                      <span className={`text-xs font-medium ${myRsvp === "yes" ? "text-green-600 dark:text-green-400" : myRsvp === "no" ? "text-muted-foreground" : "text-yellow-600 dark:text-yellow-400"}`}>
+                        {RSVP_LABELS[myRsvp]}
+                      </span>
+                    </>
+                  )}
+                </div>
+              </Link>
+            );
+          })}
+        </div>
 
-              return (
-                <Link
-                  key={event.id}
-                  href={`/events/${event.id}`}
-                  className="flex flex-col gap-1 py-2.5 first:pt-0 last:pb-0 group"
-                >
-                  <div className="flex items-start justify-between gap-2">
-                    <p className="text-sm font-medium leading-tight group-hover:text-primary transition-colors line-clamp-2">
-                      {event.title}
-                    </p>
-                    {isImminent && (
-                      <Badge variant="outline" className="text-[10px] shrink-0 border-primary text-primary">
-                        Today
-                      </Badge>
-                    )}
-                  </div>
-                  <div className="flex items-center gap-1.5 flex-wrap">
-                    <span className="text-xs text-muted-foreground truncate">
-                      {event.group.name}
-                    </span>
-                    {dateLabel && !isImminent && (
-                      <>
-                        <span className="text-xs text-muted-foreground">·</span>
-                        <span className="text-xs text-muted-foreground">{dateLabel}</span>
-                      </>
-                    )}
-                    {myRsvp && (
-                      <>
-                        <span className="text-xs text-muted-foreground">·</span>
-                        <span className={`text-xs font-medium ${myRsvp === "yes" ? "text-green-600 dark:text-green-400" : myRsvp === "no" ? "text-muted-foreground" : "text-yellow-600 dark:text-yellow-400"}`}>
-                          {RSVP_LABELS[myRsvp]}
-                        </span>
-                      </>
-                    )}
-                  </div>
-                </Link>
-              );
-            })}
-          </div>
-        )}
-
-        {upcoming && upcoming.length > 0 && (
-          <Link
-            href="/events"
-            className="mt-3 block text-xs text-muted-foreground hover:text-foreground transition-colors"
-          >
-            View all events →
-          </Link>
-        )}
+        <Link
+          href="/events"
+          className="mt-3 block text-xs text-muted-foreground hover:text-foreground transition-colors"
+        >
+          View all events →
+        </Link>
       </div>
     </aside>
   );

--- a/src/components/nav/right-panel.tsx
+++ b/src/components/nav/right-panel.tsx
@@ -19,12 +19,12 @@ export function RightPanel() {
   );
 
   if (hidden) return null;
-  // Keep the column while loading to avoid layout shift; hide once confirmed empty.
-  if (!isLoading && (!upcoming || upcoming.length === 0)) return null;
+  // Only render once we know there are events — avoids flicker on page load.
+  if (isLoading || !upcoming || upcoming.length === 0) return null;
 
   return (
     <aside className="hidden xl:block w-60 shrink-0 sticky top-0 h-screen overflow-y-auto py-4 px-3">
-      <UpcomingEventsPanel upcoming={upcoming} isLoading={isLoading} />
+      <UpcomingEventsPanel upcoming={upcoming} />
     </aside>
   );
 }


### PR DESCRIPTION
## Summary

The right panel (upcoming events) was briefly visible on every page load, even for users with no upcoming events. It showed as a column with the heading and loading skeleton, then collapsed ~300ms later once the query returned empty.

**Root cause:** `RightPanel` previously kept the `<aside>` rendered during loading (`if (!isLoading && empty) return null`), intending to prevent layout shift for users *with* events. For users *without* events this manifested as a visible flicker.

**Fix:** Return `null` while loading:
```ts
if (isLoading || !upcoming || upcoming.length === 0) return null;
```

The column now only appears once we know events exist. For users with upcoming events the column pops in after the query resolves (~300ms). For users without events, nothing ever renders.

**`UpcomingEventsPanel` simplified:** The `isLoading` prop and loading skeleton are removed — they were dead code since the parent never renders the component during loading. The `upcoming` prop is tightened to `UpcomingEvent[]` (non-nullable, always non-empty by the time this component renders).

## Security model
No auth or data changes. Layout/render logic only. `events.upcoming` remains behind `protectedProcedure` in `src/server/trpc/routers/events.ts`.

## Known tradeoffs
Users with upcoming events will see the layout shift from two-column to three-column after ~300ms on first load. This is preferable to the previous behaviour (flicker for all users regardless of events).

🤖 Generated with [Claude Code](https://claude.com/claude-code)