### PR TITLE
fix(worker): remove server-only guard from push.ts — crashes worker process

### DIFF
--- a/src/server/push.ts
+++ b/src/server/push.ts
@@ -1,4 +1,3 @@
-import "server-only";
 import webpush from "web-push";
 import { env } from "@/env";
 import { logger } from "@/lib/logger";


### PR DESCRIPTION
## Summary

The BullMQ worker process was completely non-functional. Every job (avatar processing, Steam sync, image processing, push notifications) was silently failing with a timeout from the client's perspective.

**Root cause:** `src/server/push.ts` imports `"server-only"` at line 1. The `server-only` package throws `Error: This module cannot be imported from a Client Component module` when loaded outside Next.js. The worker is a standalone Node.js/tsx process — not Next.js — so importing any module that transitively pulls in `server-only` causes an immediate crash on startup.

The import chain: `src/worker/index.ts` → `src/worker/processors/push.ts` → `src/server/push.ts` → `"server-only"` → **crash**.

**Fix:** Remove `import "server-only"` from `push.ts`. The guard was added in PR #300 to prevent `web-push` from being bundled in the browser, but `web-push` is already listed in `next.config.ts` `serverExternalPackages`, which is the correct and sufficient mechanism. The `server-only` guard was redundant for Next.js and fatal for the worker.

## Security model

No security change. `push.ts` exports `sendPush`, which is only called from the worker processor (`src/worker/processors/push.ts`) — never from client-side code. The `serverExternalPackages` config in `next.config.ts` ensures the Next.js bundler never includes `web-push` in a browser bundle.

## Known tradeoffs

None. This is a pure bug fix — no behaviour change, no new risk.