### PR TITLE
fix(config): set MINIO_PUBLIC_URL to localhost so browser can load images

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -4,7 +4,9 @@
 DATABASE_URL="postgresql://campfire:campfire@postgres:5432/campfire"
 REDIS_URL="redis://redis:6379"
 MINIO_ENDPOINT="minio"
-# Use the Docker-internal hostname so /_next/image (server-side) can fetch objects.
-# Browsers never fetch MinIO directly — they go through /_next/image.
-MINIO_PUBLIC_URL="http://minio:9000/campfire"
+# MINIO_PUBLIC_URL must be browser-accessible: avatars and images are served as
+# plain <img> tags (not via /_next/image), so the browser fetches MinIO directly.
+# next.config.ts remotePatterns allows both "minio" (server-side image opt) and
+# "localhost" (direct browser fetches) for correctness in both paths.
+MINIO_PUBLIC_URL="http://localhost:9000/campfire"
 SMTP_HOST="mailhog"

--- a/next.config.ts
+++ b/next.config.ts
@@ -5,14 +5,14 @@ type RemotePattern = NonNullable<NonNullable<NextConfig["images"]>["remotePatter
 /**
  * Derive next/image remotePatterns entries for MinIO.
  *
- * /_next/image fetches the src URL server-side. In Docker Compose, the app
- * container must use the internal hostname (e.g. "minio") to reach MinIO,
- * not the browser-facing "localhost". We therefore allow both:
- *   1. MINIO_PUBLIC_URL origin — what storageUrl() stores; the server-reachable base.
- *   2. MINIO_ENDPOINT + MINIO_PORT — the direct internal hostname, so that URLs
- *      stored before MINIO_PUBLIC_URL was configured also continue to work.
+ * Avatars and post images are served as plain <img> tags (not via /_next/image),
+ * so MINIO_PUBLIC_URL must be browser-accessible (e.g. http://localhost:9000/campfire).
+ * The app container reaches MinIO via MINIO_ENDPOINT (e.g. "minio"), which is separate.
  *
- * Browsers never fetch MinIO directly — they always go through /_next/image.
+ * We allow both origins so that:
+ *   1. MINIO_PUBLIC_URL origin — what storageUrl() stores; the browser-accessible URL.
+ *   2. MINIO_ENDPOINT + MINIO_PORT — URLs stored before MINIO_PUBLIC_URL was configured,
+ *      and any server-side image optimisation paths that use the internal hostname.
  */
 function minioRemotePatterns(): RemotePattern[] {
   const patterns: RemotePattern[] = [];


### PR DESCRIPTION
## Summary

All uploaded avatars and post images were silently 404ing in the browser.

**Root cause:** `.env.docker` set `MINIO_PUBLIC_URL=http://minio:9000/campfire`. `storageUrl()` uses this to build every URL stored in the database. `minio` is the Docker-internal hostname — unreachable from a browser. The images were being processed correctly and stored in MinIO, but the URLs in the DB were never loadable.

The assumption in the original comment ("Browsers never fetch MinIO directly — they go through `/_next/image`") was incorrect. Avatars and post images use plain `<img>` tags (Radix `AvatarImage`, plain `<img>` in posts), not `next/image`. The browser fetches MinIO directly.

**Fix:** Change `MINIO_PUBLIC_URL` to `http://localhost:9000/campfire` — the browser-accessible address. `MINIO_ENDPOINT` stays as `"minio"` for the app container's internal connection.

Also fixed the existing bad URL in the database via a one-time `UPDATE` (not in this diff — run directly against the local DB).

## Security model

No auth/authz changes. `.env.docker` is checked in and contains no secrets (it only sets Docker hostnames). The MinIO bucket is already publicly readable for served objects.

## Known tradeoffs

This config assumes local development on `localhost`. A production deployment would set `MINIO_PUBLIC_URL` to the CDN/proxy URL via the `.env` file (not `.env.docker`), which is the intended pattern.