### PR TITLE
feat(games): sort control in library toolbar (CAMP-174)

### DIFF
--- a/src/app/(app)/games/page.tsx
+++ b/src/app/(app)/games/page.tsx
@@ -475,8 +475,9 @@ const SORT_LABELS: Record<SortOption, string> = {
 
 /** Format playtime minutes as "142h 33m" (or "33m" if under an hour). */
 function formatPlaytime(minutes: number): string {
-  const h = Math.floor(minutes / 60);
-  const m = minutes % 60;
+  const total = Math.round(Math.abs(minutes));
+  const h = Math.floor(total / 60);
+  const m = total % 60;
   if (h === 0) return `${m}m`;
   if (m === 0) return `${h}h`;
   return `${h}h ${m}m`;
@@ -541,7 +542,10 @@ export default function GamesPage() {
               {/* Sort selector */}
               <select
                 value={sort}
-                onChange={(e) => setSortOption(e.target.value as SortOption)}
+                onChange={(e) => {
+                  const v = e.target.value;
+                  if (Object.hasOwn(SORT_LABELS, v)) setSortOption(v as SortOption);
+                }}
                 className="rounded-md border bg-background px-2 py-1.5 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
                 aria-label="Sort games"
               >


### PR DESCRIPTION
## Summary

Closes #337 (CAMP-174). The backend sort support (tRPC `sort` param, SQL ordering) was shipped in PR #350. This PR adds the UI.

- **Sort dropdown** in the library toolbar (A–Z / Most played / Recently played / Recently added), next to the view-mode toggle
- **Persisted to localStorage** under key `games-sort`, read on mount after hydration (same pattern as `games-view-mode`)
- **List view**: playtime shown inline (`142h 33m` / `33m`) when sort is `most_played` or `recently_played` and the game has playtime data
- **Grid view**: playtime badge shown on card hover when playtime data exists (regardless of sort mode)
- `formatPlaytime(minutes)` helper: `0–59m` → `"33m"`, `60+m` → `"2h"` / `"142h 33m"`

## Security model

Read-only UI change. `myGames` is a `protectedProcedure` — only returns the authenticated user's own library.

## Known tradeoffs

- Playtime in list view is only shown for `most_played` and `recently_played` sorts to avoid clutter in the default A–Z view. It's always visible on hover in grid view.
- `<select>` for the sort control — simple and accessible. Could be upgraded to a Radix dropdown in a future polish pass.