### PR TITLE
feat(profile): gaming stats section on Overview tab (CAMP-175)

### DIFF
--- a/src/app/(app)/profile/page.tsx
+++ b/src/app/(app)/profile/page.tsx
@@ -367,7 +367,7 @@ export default function MyProfilePage() {
                         />
                         <span className="flex-1 text-sm truncate">{g.name}</span>
                         <span className="text-xs text-muted-foreground tabular-nums shrink-0">
-                          {formatPlaytime(g.playtime2weeks)} this period
+                          {formatPlaytime(g.playtime2weeks ?? 0)} this period
                         </span>
                       </div>
                     ))}

--- a/src/server/trpc/routers/games.ts
+++ b/src/server/trpc/routers/games.ts
@@ -441,8 +441,22 @@ export const gamesRouter = createTRPCRouter({
 
     const totalMinutes = Number(totalRow[0]?.total ?? 0);
 
-    const recentlyPlayed = (me.recentlyPlayedJson as RecentlyPlayedEntry[] | null) ?? [];
-    const last2WeeksMinutes = recentlyPlayed.reduce((sum, g) => sum + (g.playtime2weeks ?? 0), 0);
+    // Validate recentlyPlayedJson entries — the field is populated by an external
+    // worker and the stored JSON may be missing fields if the schema ever evolves.
+    // Filter to entries that have the minimum required shape before returning.
+    const rawPlayed = (me.recentlyPlayedJson as RecentlyPlayedEntry[] | null) ?? [];
+    const recentlyPlayed = rawPlayed
+      .filter(
+        (g): g is RecentlyPlayedEntry =>
+          typeof g === "object" &&
+          g !== null &&
+          typeof g.appId === "number" &&
+          typeof g.name === "string" &&
+          typeof g.playtime2weeks === "number"
+      )
+      .slice(0, 3);
+
+    const last2WeeksMinutes = recentlyPlayed.reduce((sum, g) => sum + g.playtime2weeks, 0);
 
     return {
       steamLinked,
@@ -455,7 +469,7 @@ export const gamesRouter = createTRPCRouter({
         coverUrl: r.coverUrl,
         playtimeMinutes: r.playtimeMinutes ?? 0,
       })),
-      recentlyPlayed: recentlyPlayed.slice(0, 3),
+      recentlyPlayed,
     };
   }),
 


### PR DESCRIPTION
## Summary

- Adds `games.gamingStats` tRPC procedure: aggregates Steam playtime from `game_ownerships` and the user's stored `recentlyPlayedJson`
- Adds a **Gaming Activity** card to the profile Overview tab, visible only when Steam is linked and `steamLibraryPublic = true`
- Displays: total playtime, last-2-weeks playtime, top 3 most played (with cover art), top 3 recently played (with Steam capsule art)

## Security model

- `gamingStats` is a `protectedProcedure` — requires a valid session
- All queries are scoped to `ctx.user.id`; no cross-user data is returned
- `recentlyPlayedJson` is read from the caller's own `user` row; the Steam sync worker (external code) populates it during the scheduled library import
- The UI gate (`steamLinked && libraryPublic`) mirrors the server-side data — even without the gate, the procedure returns empty arrays for unlinked accounts

## Known tradeoffs

- **recentlyPlayedJson currency**: this field is populated by the Steam sync BullMQ job. If the job hasn't run recently the "recently played" list may be stale. No timestamp is shown because we don't store `syncedAt` for this field yet. This is acceptable for MVP.
- **Steam capsule images**: the recently played section uses `cdn.akamai.steamstatic.com` capsule URLs constructed from `appId`. These are already allowed in `next.config.ts` remotePatterns. Games that aren't on Steam (added manually or via IGDB) won't appear here since `recentlyPlayedJson` only comes from the Steam API.
- **Most played ordering**: the top-3 most played query orders by `playtimeMinutes DESC` over all `game_ownerships` rows for the user, then joins to `games` for title/cover. This is a small bounded query at MVP scale.

## Test plan

- [ ] Link Steam in Settings → profile Overview tab shows Gaming Activity card
- [ ] Set library to private → card disappears
- [ ] Card shows correct total / last-2-weeks hours
- [ ] Most played section shows up to 3 games with cover art and formatted playtime
- [ ] Recently played section shows up to 3 games with Steam capsule art
- [ ] No Steam linked → card is not rendered at all
- [ ] `pnpm typecheck && pnpm lint` both pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)